### PR TITLE
Scope hub layout styling away from /customiize

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -61,16 +61,15 @@ function customiizer_enqueue_customize_assets() {
         wp_enqueue_style('customiizer-style', get_stylesheet_directory_uri() . '/styles/style.css', [], $ver);
         wp_enqueue_style('preview-image-style', get_stylesheet_directory_uri() . '/styles/preview_image.css', [], $ver);
 
-        $needs_customize_styles = (
-                strpos($request_uri, '/customiize') !== false ||
+        $needs_hub_layout_styles = (
                 strpos($request_uri, '/v2shop') !== false ||
                 strpos($request_uri, '/configurateur') !== false ||
                 strpos($request_uri, '/boutique') !== false ||
                 strpos($request_uri, '/mycreation') !== false
         );
 
-        if ($needs_customize_styles) {
-                wp_enqueue_style('customize-style', get_stylesheet_directory_uri() . '/styles/customize.css', [], $ver);
+        if ($needs_hub_layout_styles) {
+                wp_enqueue_style('hub-layout-style', get_stylesheet_directory_uri() . '/styles/hub-layout.css', [], $ver);
         }
 
        wp_enqueue_style('header-style', get_stylesheet_directory_uri() . '/styles/header.css', [], $ver);
@@ -284,8 +283,6 @@ function customiizer_enqueue_customize_assets() {
 
        if (is_front_page() || is_page('home')) {
                wp_enqueue_style('mobile-home', get_stylesheet_directory_uri() . '/styles/responsive/mobile/home.css', [], $ver, 'all');
-       } elseif (strpos($request_uri, '/customiize') !== false) {
-               wp_enqueue_style('mobile-customize', get_stylesheet_directory_uri() . '/styles/responsive/mobile/customize.css', [], $ver, 'all');
        } elseif (strpos($request_uri, '/configurateur') !== false) {
                wp_enqueue_style('mobile-product', get_stylesheet_directory_uri() . '/styles/responsive/mobile/product.css', [], $ver, 'all');
                wp_enqueue_style('mobile-design-product', get_stylesheet_directory_uri() . '/styles/responsive/mobile/design_product.css', [], $ver, 'all');
@@ -304,5 +301,9 @@ function customiizer_enqueue_customize_assets() {
                strpos($request_uri, '/cookies') !== false
        ) {
                wp_enqueue_style('mobile-legal', get_stylesheet_directory_uri() . '/styles/responsive/mobile/legal.css', [], $ver, 'all');
+       }
+
+       if ($needs_hub_layout_styles) {
+               wp_enqueue_style('mobile-hub-layout', get_stylesheet_directory_uri() . '/styles/responsive/mobile/hub-layout.css', [], $ver, 'all');
        }
 }

--- a/styles/hub-layout.css
+++ b/styles/hub-layout.css
@@ -1,23 +1,22 @@
-#customize-main {
+/* Layout principal pour les pages type hub (v2shop, configurateur, boutique, mycreation). */
+#customize-main.hub-layout {
     flex-grow: 1;
     height: calc(100dvh - var(--header-height, 88px));
     min-height: calc(100dvh - var(--header-height, 88px));
     color: #f5f7f4;
     font-family: 'Inter', 'Arial', sans-serif;
     background: linear-gradient(160deg, #111111 0%, #131313 50%, #1a1a1a 100%);
-}
-#customize-main.customize-layout {
     display: flex; /* Assure que tous les enfants de customize-main sont alignés horizontalement */
 }
-body.customize-layout-page > #content,
-body.customize-layout-page #site-content.full-content,
-body.customize-layout-page #customize-main.customize-layout {
+body.hub-layout-page > #content,
+body.hub-layout-page #site-content.full-content,
+body.hub-layout-page #customize-main.hub-layout {
     width: 100%;
     max-width: none;
     margin: 0;
 }
 
-.sidebar {
+#customize-main.hub-layout .sidebar {
     flex: 0 0 auto;
     height: calc(100dvh - var(--header-height, 88px));
     display: flex;
@@ -28,14 +27,14 @@ body.customize-layout-page #customize-main.customize-layout {
     box-shadow: 0 24px 40px rgba(0, 0, 0, 0.55);
 }
 
-#sidebar-main {
+#customize-main.hub-layout #sidebar-main {
     display: flex;
     flex-direction: column;
     height: 100%; /* Assurez-vous que cela prend toute la hauteur de la sidebar */
 }
 
 
-#left-sidebar {
+#customize-main.hub-layout #left-sidebar {
     height: 100%;
     display: flex; /* Assurer que les enfants peuvent utiliser flexbox */
     flex-direction: column; /* Aligner les enfants en colonne */
@@ -48,14 +47,14 @@ body.customize-layout-page #customize-main.customize-layout {
     border-radius: 28px 0 0 28px;
 }
 
-#right-sidebar {
+#customize-main.hub-layout #right-sidebar {
     width: 280px;
     background: #141414;
     border-left: 1px solid rgba(5, 5, 5, 0.7);
     border-radius: 0 28px 28px 0;
 }
 
-body.customize-layout-page #customize-main.customize-layout > #content {
+body.hub-layout-page #customize-main.hub-layout > #content {
     flex: 1 1 70%; /* Répartition 70/30 avec la sidebar */
     width: 70%;
     max-width: 70%;
@@ -69,17 +68,17 @@ body.customize-layout-page #customize-main.customize-layout > #content {
     min-width: 0; /* Évite les débordements lors du calcul flex */
 }
 
-#sidebar-header,
-#sidebar-footer {
+#customize-main.hub-layout #sidebar-header,
+#customize-main.hub-layout #sidebar-footer {
     background: transparent;
     color: inherit;
 }
 
-#sidebar-header {
+#customize-main.hub-layout #sidebar-header {
     padding: 24px 28px 18px;
 }
 
-#sidebar-content {
+#customize-main.hub-layout #sidebar-content {
     display: flex;
     flex-direction: column; /* Organisation verticale des éléments */
     padding: 0 28px 28px;
@@ -89,13 +88,13 @@ body.customize-layout-page #customize-main.customize-layout > #content {
 }
 
 
-#sidebar-footer {
+#customize-main.hub-layout #sidebar-footer {
     padding: 22px 28px 26px;
     align-items: center; /* Centre verticalement */
     text-align: center;
 }
 
-#right-sidebar .title {
+#customize-main.hub-layout #right-sidebar .title {
     font-size: 1.05rem;
     font-weight: 600;
     letter-spacing: 0.01em;
@@ -103,18 +102,18 @@ body.customize-layout-page #customize-main.customize-layout > #content {
     color: #f4f4f4;
 }
 
-#sidebar-content::-webkit-scrollbar,
-#user_images::-webkit-scrollbar {
+#customize-main.hub-layout #sidebar-content::-webkit-scrollbar,
+#customize-main.hub-layout #user_images::-webkit-scrollbar {
     width: 6px;
 }
 
-#sidebar-content::-webkit-scrollbar-thumb,
-#user_images::-webkit-scrollbar-thumb {
+#customize-main.hub-layout #sidebar-content::-webkit-scrollbar-thumb,
+#customize-main.hub-layout #user_images::-webkit-scrollbar-thumb {
     background: linear-gradient(135deg, var(--color-brand-600, #148556), var(--color-brand-400, #2bd879));
     border-radius: 9999px;
 }
 
-#user_images {
+#customize-main.hub-layout #user_images {
     display: flex;
     flex-direction: column;
     gap: 18px;
@@ -123,7 +122,7 @@ body.customize-layout-page #customize-main.customize-layout > #content {
     max-height: calc(100dvh - 160px);
 }
 
-#user_images img {
+#customize-main.hub-layout #user_images img {
     width: 100%;
     border-radius: 18px;
     display: block;
@@ -133,17 +132,17 @@ body.customize-layout-page #customize-main.customize-layout > #content {
     transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
-#user_images img:hover {
+#customize-main.hub-layout #user_images img:hover {
     border-color: var(--color-brand-500, #1fb86c);
     transform: translateY(-2px);
 }
 
-#user_images p {
+#customize-main.hub-layout #user_images p {
     font-size: 0.95rem;
     color: rgba(255, 255, 255, 0.55);
     margin: 0;
 }
 
-.hidden {
+#customize-main.hub-layout .hidden {
     display: none;
 }

--- a/styles/responsive/mobile/customize.css
+++ b/styles/responsive/mobile/customize.css
@@ -1,1 +1,0 @@
-/* CSS removed per request */

--- a/styles/responsive/mobile/hub-layout.css
+++ b/styles/responsive/mobile/hub-layout.css
@@ -1,0 +1,1 @@
+/* Placeholder responsive overrides for the hub layout (intentionally left empty). */

--- a/templates/customize.php
+++ b/templates/customize.php
@@ -35,7 +35,34 @@ function load_main_content() {
 }
 
 $path = $_SERVER['REQUEST_URI'];
-$is_customize_layout = (strpos($path, '/customiize') !== false || strpos($path, '/v2shop') !== false);
+$is_customiize_page = strpos($path, '/customiize') !== false;
+$is_hub_layout = (
+        !$is_customiize_page && (
+                strpos($path, '/v2shop') !== false ||
+                strpos($path, '/configurateur') !== false ||
+                strpos($path, '/boutique') !== false ||
+                strpos($path, '/mycreation') !== false
+        )
+);
+
+$body_classes = [];
+if ($is_customiize_page) {
+        $body_classes[] = 'customize-layout-page';
+}
+if ($is_hub_layout) {
+        $body_classes[] = 'customize-layout-page';
+        $body_classes[] = 'hub-layout-page';
+}
+
+$main_classes = [];
+if ($is_customiize_page) {
+        $main_classes[] = 'customize-layout';
+}
+if ($is_hub_layout) {
+        $main_classes[] = 'customize-layout';
+        $main_classes[] = 'hub-layout';
+}
+$main_class_attribute = $main_classes ? ' class="' . esc_attr(implode(' ', $main_classes)) . '"' : '';
 ?>
 
 <!DOCTYPE html>
@@ -44,9 +71,9 @@ $is_customize_layout = (strpos($path, '/customiize') !== false || strpos($path, 
                 <meta charset="utf-8">
                 <?php wp_head(); ?>
         </head>
-        <body <?php body_class( $is_customize_layout ? 'customize-layout-page' : '' ); ?>>
+        <body <?php body_class( $body_classes ); ?>>
                 <main id="site-content" class="full-content">
-                        <div id="customize-main"<?php echo $is_customize_layout ? ' class="customize-layout"' : ''; ?>>
+                        <div id="customize-main"<?php echo $main_class_attribute; ?>>
 				<?php if (strpos($_SERVER['REQUEST_URI'], '/customiize') !== false) { ?>
 				<?php get_template_part('templates/generate/customize', 'main'); ?>
 				<?php } ?>


### PR DESCRIPTION
## Summary
- rename the shared customize stylesheet to hub-layout and scope its selectors so the /customiize page is no longer affected
- update the customize template to add hub-layout classes only on non-/customiize routes
- adjust asset registration to enqueue the renamed desktop and mobile hub layout styles where needed

## Testing
- php -l templates/customize.php

------
https://chatgpt.com/codex/tasks/task_e_68d9c045c6f88322a9ed669c466af89b