### PR TITLE
Limit customiize layout height to viewport

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -14,6 +14,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) {
     display: flex;
     gap: 24px;
+    height: calc(100dvh - var(--header-height, 88px));
     min-height: calc(100dvh - var(--header-height, 88px));
     padding: 24px;
     box-sizing: border-box;
@@ -23,6 +24,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) #left-sidebar {
     flex: 0 0 30%;
     max-width: 30%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     background: rgba(17, 17, 17, 0.85);
     border-radius: 24px;
     border: 1px solid rgba(255, 255, 255, 0.08);
@@ -33,6 +37,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) > #content {
     flex: 1 1 70%;
     max-width: 70%;
+    height: 100%;
     background: rgba(10, 10, 10, 0.85);
     border-radius: 24px;
     border: 1px solid rgba(255, 255, 255, 0.05);
@@ -42,3 +47,34 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     flex-direction: column;
 }
+
+#customize-main.customize-layout:not(.hub-layout) #left-sidebar #content-container {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding-right: 8px;
+}
+
+#customize-main.customize-layout:not(.hub-layout) #left-sidebar #content-container::-webkit-scrollbar {
+    width: 6px;
+}
+
+#customize-main.customize-layout:not(.hub-layout) #left-sidebar #content-container::-webkit-scrollbar-thumb {
+    background: linear-gradient(135deg, var(--color-brand-600, #148556), var(--color-brand-400, #2bd879));
+    border-radius: 9999px;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding-right: 8px;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {
+    width: 8px;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar-thumb {
+    background: linear-gradient(135deg, var(--color-brand-600, #148556), var(--color-brand-400, #2bd879));
+    border-radius: 9999px;
+}
+


### PR DESCRIPTION
## Summary
- limit the /customiize layout container to the viewport height and enable internal scrolling for the sidebar and main content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c8d7093c83229abbf730a1879251