### PR TITLE
Center images within content container

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -54,6 +54,12 @@ body > #content {
   margin: 0;
 }
 
+#content img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* Ensure body and Astra container share the same background */
 body,
 .ast-separate-container {


### PR DESCRIPTION
## Summary
- ensure images within the main content wrapper are displayed as block elements
- apply automatic horizontal margins so inline images are centered by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cac706b48322a3c6145c47ac901b