### PR TITLE
Arrange customize grid layout

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -69,6 +69,44 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     flex: 1 1 auto;
     overflow-y: auto;
     padding-right: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    min-height: 0;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .grid-wrapper {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    width: 100%;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: 1fr;
+    gap: 16px;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container {
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- arrange the customize page image grid into a two-by-two layout using CSS grid
- ensure the gallery stretches with its container and images cover their tiles cleanly

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9cb45a20883228e092a22086a789a