### PR TITLE
Ensure image grid tiles are square and preserve image ratio

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -120,12 +120,13 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     align-items: center;
     justify-content: center;
+    aspect-ratio: 1 / 1;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- enforce a 1:1 aspect ratio on image grid containers in the customization view
- switch grid images to use object-fit: contain so thumbnails no longer stretch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cde7dcb083229c219b34f4f1ed33