### PR TITLE
Ensure customization image grid tiles stay square

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -85,7 +85,6 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-auto-rows: 1fr;
     gap: 16px;
     width: 100%;
     height: 100%;
@@ -120,12 +119,13 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     align-items: center;
     justify-content: center;
+    aspect-ratio: 1 / 1;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- adjust the customization image grid styling so each tile remains square regardless of layout
- center preview images with contain sizing to preserve their native aspect ratios within the square frame

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9cf3542a48322ae482056dc0e05a9