### PR TITLE
Make image grid tiles square with contained images

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -85,7 +85,6 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-auto-rows: 1fr;
     gap: 16px;
     width: 100%;
     height: 100%;
@@ -120,12 +119,13 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     align-items: center;
     justify-content: center;
+    aspect-ratio: 1 / 1;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- update the generation image grid so each tile keeps a square footprint
- ensure preview images scale with their intrinsic ratios inside the square containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d1bdbbc48322a63277c22a1172a3