### PR TITLE
Fix overlapping customize images

### DIFF
--- a/js/generate/generate.js
+++ b/js/generate/generate.js
@@ -84,7 +84,7 @@ jQuery(function($) {
                         gridContainer.innerHTML = '';
                         for (let i = 0; i < 4; i++) {
                                 const wrapper = document.createElement('div');
-                                wrapper.className = `image-container ${i < 2 ? 'top' : 'bottom'}`;
+                                wrapper.className = `customize-image-slot ${i < 2 ? 'top' : 'bottom'}`;
 
                                 const image = document.createElement('img');
                                 image.className = i < 2 ? 'top' : 'bottom';

--- a/js/generate/show_images.js
+++ b/js/generate/show_images.js
@@ -50,7 +50,7 @@ function displayImages() {
                                         .addClass(i < 2 ? 'top' : 'bottom');
 
                                 var imgContainer = jQuery('<div>')
-                                        .addClass('image-container ' + (i < 2 ? 'top' : 'bottom'))
+                                        .addClass('customize-image-slot ' + (i < 2 ? 'top' : 'bottom'))
                                         .append(imgElement);
 
                                 gridContainer.append(imgContainer);
@@ -75,7 +75,7 @@ function displayImages() {
                                         .addClass(index < 2 ? 'top' : 'bottom');
 
                                 var imgContainer = jQuery('<div>')
-                                        .addClass('image-container ' + (index < 2 ? 'top' : 'bottom'))
+                                        .addClass('customize-image-slot ' + (index < 2 ? 'top' : 'bottom'))
                                         .append(imgElement);
 
                                 gridContainer.append(imgContainer);

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -110,7 +110,8 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
 }
 
-#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container {
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .customize-image-slot {
+    /* Classe dédiée pour éviter les collisions avec d'autres .image-container globaux */
     position: relative;
     overflow: hidden;
     border-radius: 16px;
@@ -119,10 +120,11 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-wrap: nowrap;
     aspect-ratio: 1 / 1;
 }
 
-#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {
+#customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .customize-image-slot img {
     width: 100%;
     height: 100%;
     object-fit: contain;

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -12,16 +12,16 @@
 <div class="content-images" id="content-images">
         <div class="grid-wrapper">
                 <div id="image-grid" class="image-grid">
-                        <div class="image-container top">
+                        <div class="customize-image-slot top">
                                 <img class="top" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 0" />
                         </div>
-                        <div class="image-container top">
+                        <div class="customize-image-slot top">
                                 <img class="top" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 1" />
                         </div>
-                        <div class="image-container bottom">
+                        <div class="customize-image-slot bottom">
                                 <img class="bottom" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 2" />
                         </div>
-                        <div class="image-container bottom">
+                        <div class="customize-image-slot bottom">
                                 <img class="bottom" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 3" />
                         </div>
                 </div>


### PR DESCRIPTION
## Summary
- isolate the customize page image cells under a dedicated class to avoid global CSS conflicts
- update JavaScript placeholders to use the new class so generated images render with the scoped styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d6c5b07c8322b5e82d188df46574