### PR TITLE
Prevent custom image grid from exceeding viewport

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -67,7 +67,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images {
     flex: 1 1 auto;
-    overflow-y: auto;
+    overflow: hidden;
     padding-right: 8px;
     display: flex;
     flex-direction: column;
@@ -79,15 +79,19 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     flex: 1 1 auto;
     min-height: 0;
     width: 100%;
+    display: flex;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(0, 1fr));
     gap: 16px;
     width: 100%;
     min-height: 0;
-    align-content: start;
+    height: 100%;
+    align-content: stretch;
+    align-items: stretch;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid.is-hidden {
@@ -118,7 +122,8 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     align-items: center;
     justify-content: center;
-    aspect-ratio: 1 / 1;
+    min-width: 0;
+    min-height: 0;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container img {


### PR DESCRIPTION
## Summary
- stop the custom layout image grid container from scrolling by keeping it within the available page height
- stretch the grid and image containers so preview tiles resize with the viewport while remaining centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9dcb0690c8322b0eedd9b2ae0b505