### PR TITLE
Affiche la progression en ligne sur Customiize

### DIFF
--- a/js/generate/generate.js
+++ b/js/generate/generate.js
@@ -25,6 +25,7 @@ jQuery(function($) {
         const customTextInput = document.getElementById('custom-text');
         const alertBox = document.getElementById('alert-box');
         const placeholderDiv = document.getElementById('placeholder');
+        const inlineProgressWrapper = document.getElementById('generation-progress-inline-wrapper');
         const savedPromptText = localStorage.getItem('savedPromptText');
         const PLACEHOLDER_IMAGE_SRC = 'https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png';
 
@@ -152,6 +153,8 @@ jQuery(function($) {
         if (document.body) {
                 document.body.dataset.generationPage = '1';
         }
+
+        setupInlineProgressDisplay();
 
         if (savedPromptText) {
                 customTextInput.textContent = savedPromptText;
@@ -626,6 +629,7 @@ jQuery(function($) {
 
                 modal.classList.remove('hide');
                 modal.setAttribute('aria-hidden', 'false');
+                updateInlineProgressVisibility(modal, true);
                 loadingToggled = true;
         }
 
@@ -637,7 +641,44 @@ jQuery(function($) {
 
                 modal.classList.add('hide');
                 modal.setAttribute('aria-hidden', 'true');
+                updateInlineProgressVisibility(modal, false);
                 loadingToggled = false;
+        }
+
+        function setupInlineProgressDisplay() {
+                if (!inlineProgressWrapper) {
+                        return;
+                }
+
+                const modal = document.getElementById('generation-progress-modal');
+                if (!modal) {
+                        return;
+                }
+
+                inlineProgressWrapper.appendChild(modal);
+                inlineProgressWrapper.setAttribute('aria-hidden', modal.classList.contains('hide') ? 'true' : 'false');
+
+                modal.classList.add('inline-mode');
+                modal.setAttribute('role', 'region');
+                modal.setAttribute('aria-modal', 'false');
+                modal.setAttribute('aria-hidden', modal.classList.contains('hide') ? 'true' : 'false');
+
+                const dialog = modal.querySelector('.generation-progress-dialog');
+                if (dialog) {
+                        dialog.classList.add('inline-mode');
+                        dialog.setAttribute('role', 'presentation');
+                }
+
+                updateInlineProgressVisibility(modal, !modal.classList.contains('hide'));
+        }
+
+        function updateInlineProgressVisibility(modal, isVisible) {
+                if (!inlineProgressWrapper || !modal || !inlineProgressWrapper.contains(modal)) {
+                        return;
+                }
+
+                inlineProgressWrapper.classList.toggle('is-active', Boolean(isVisible));
+                inlineProgressWrapper.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
         }
 
         function getStoredProgressState() {

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -94,6 +94,46 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     min-height: 0;
 }
 
+#customize-main.customize-layout:not(.hub-layout) #generation-progress-inline-wrapper {
+    display: none;
+    width: 100%;
+    padding: 0 8px;
+    box-sizing: border-box;
+}
+
+#customize-main.customize-layout:not(.hub-layout) #generation-progress-inline-wrapper.is-active {
+    display: flex;
+    justify-content: center;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    #generation-progress-inline-wrapper
+    .generation-progress-modal.inline-mode {
+    position: static;
+    right: auto;
+    bottom: auto;
+    max-width: min(520px, 100%);
+    width: 100%;
+    pointer-events: auto;
+    z-index: auto;
+    align-items: stretch;
+    justify-content: center;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    #generation-progress-inline-wrapper
+    .generation-progress-dialog.inline-mode {
+    width: 100%;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    #generation-progress-inline-wrapper
+    .generation-progress-dialog.inline-mode
+    .loading-container {
+    box-shadow: none;
+    background: rgba(18, 18, 18, 0.88);
+}
+
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .grid-wrapper {
     flex: 1 1 auto;
     min-height: 0;

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -10,6 +10,8 @@
 -->
 
 <div class="content-images" id="content-images">
+        <div id="generation-progress-inline-wrapper" class="generation-progress-inline-wrapper" role="region" aria-live="polite" aria-hidden="true"></div>
+
         <div class="grid-wrapper">
                 <div id="image-grid" class="image-grid">
                         <div class="image-container top">


### PR DESCRIPTION
## Summary
- afficher la barre de progression directement dans la page Customiize au-dessus de la prévisualisation
- adapter le script de génération pour déplacer le composant de progression et gérer l’accessibilité de l’affichage en ligne
- styliser la barre de progression pour le layout Customiize afin qu’elle s’intègre dans la colonne d’aperçu

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9f39f63108322b50c102b1897f45d