### PR TITLE
Expose les couleurs des variantes dans get_product_ratios

### DIFF
--- a/includes/products.php
+++ b/includes/products.php
@@ -17,12 +17,14 @@ function get_product_ratios() {
     global $wpdb;
 
     $results = $wpdb->get_results("
-        SELECT 
+        SELECT
             p.product_id,
             p.name AS product_name,
             v.variant_id,
             v.size,
             v.ratio_image,
+            v.color,
+            v.hexa,
             m.image
         FROM WPC_products p
         INNER JOIN WPC_variants v ON p.product_id = v.product_id

--- a/js/generate/show_ratio.js
+++ b/js/generate/show_ratio.js
@@ -375,10 +375,40 @@ function buildVariantItem(variant) {
     image.alt = variant.product_name.includes('Clear Case') ? '' : (variant.size || 'Format');
     item.appendChild(image);
 
-    if (!variant.product_name.includes('Clear Case')) {
+    const metaWrapper = document.createElement('div');
+    metaWrapper.className = 'product-item__meta';
+
+    if (!variant.product_name.includes('Clear Case') && variant.size) {
         const sizeText = document.createElement('p');
         sizeText.textContent = variant.size;
-        item.appendChild(sizeText);
+        sizeText.className = 'product-item__size';
+        metaWrapper.appendChild(sizeText);
+    }
+
+    const colorLabel = typeof variant.color === 'string' ? variant.color.trim() : '';
+    const colorHex = typeof variant.hexa === 'string' ? variant.hexa.trim() : '';
+    if (colorLabel) {
+        const colorRow = document.createElement('p');
+        colorRow.className = 'product-item__color';
+
+        const colorText = document.createElement('span');
+        colorText.className = 'product-item__color-label';
+        colorText.textContent = colorLabel;
+
+        if (colorHex) {
+            const colorDot = document.createElement('span');
+            colorDot.className = 'product-item__color-dot';
+            colorDot.style.backgroundColor = colorHex;
+            colorDot.setAttribute('aria-hidden', 'true');
+            colorRow.appendChild(colorDot);
+        }
+        colorRow.appendChild(colorText);
+        colorRow.setAttribute('title', colorLabel);
+        metaWrapper.appendChild(colorRow);
+    }
+
+    if (metaWrapper.childElementCount > 0) {
+        item.appendChild(metaWrapper);
     }
 
     item.addEventListener('click', () => {
@@ -444,6 +474,11 @@ function updateSelectedInfo(variant) {
     }
     if (variant.size) {
         parts.push(variant.size);
+    }
+
+    const colorLabel = typeof variant.color === 'string' ? variant.color.trim() : '';
+    if (colorLabel) {
+        parts.push(colorLabel);
     }
 
     const label = parts.join(' · ') || 'Sélectionnez un format';

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -266,6 +266,65 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .variant-display
+    .product-item__meta,
+#customize-main.customize-layout:not(.hub-layout)
+    #left-sidebar
+    .product-item__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: center;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .variant-display
+    .product-item__color,
+#customize-main.customize-layout:not(.hub-layout)
+    #left-sidebar
+    .product-item__color {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: rgba(244, 248, 247, 0.78);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .variant-display
+    .product-item__color-dot,
+#customize-main.customize-layout:not(.hub-layout)
+    #left-sidebar
+    .product-item__color-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .variant-display
+    .product-item__color-label,
+#customize-main.customize-layout:not(.hub-layout)
+    #left-sidebar
+    .product-item__color-label {
+    display: inline-flex;
+    align-items: center;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .variant-display
     .product-item:hover,
 #customize-main.customize-layout:not(.hub-layout)
     > #content


### PR DESCRIPTION
## Summary
- ajoute les colonnes de couleur et de code hexa au flux get_product_ratios
- permet à l’interface Customiize d’afficher le libellé et l’indicateur de couleur pour chaque variante

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9a1dabd88322b9a6956d3aea9868