### PR TITLE
Adjust guest header elements

### DIFF
--- a/header.php
+++ b/header.php
@@ -72,10 +72,6 @@ if ( $user_logged_in ) {
                                                         <span class="loyalty-header-points-value"><?php echo esc_html( number_format_i18n( $loyalty_points ) ); ?></span>
                                                         <span class="loyalty-header-points-label"><?php echo esc_html__( 'pts', 'customiizer' ); ?></span>
                                                 </div>
-                                                <?php else : ?>
-                                                <div class="loyalty-header-points loyalty-header-points--guest">
-                                                        <span class="loyalty-header-points-label"><?php echo esc_html__( 'Découvrir', 'customiizer' ); ?></span>
-                                                </div>
                                                 <?php endif; ?>
                                                 <?php customiizer_loyalty_widget(); ?>
                                         </div>
@@ -115,9 +111,8 @@ if ( $user_logged_in ) {
         </div>
         <?php endif; ?>
         <div class="login-register-container">
-                <a id="loginRegisterButton" class="icon-button">
-                        <i class="fas fa-user"></i>
-                        <span class="login-text">Se connecter</span>
+                <a id="loginRegisterButton" class="icon-button" aria-label="<?php echo esc_attr__( 'Se connecter', 'customiizer' ); ?>">
+                        <i class="fas fa-user" aria-hidden="true"></i>
                 </a>
         </div>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- hide the loyalty points badge for guests in the header
- update the login button to display only the user icon while keeping accessibility labeling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68daa1020c608322a98fa7a9ff80386c