### PR TITLE
Display generated image preview with selectable thumbnails

### DIFF
--- a/js/generate/show_images.js
+++ b/js/generate/show_images.js
@@ -1,5 +1,194 @@
 var allImages = [];
 const PLACEHOLDER_IMAGE_SRC = 'https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png';
+const GENERATION_THUMBNAIL_LIMIT = 3;
+
+function normalizePromptValue(prompt) {
+        if (!prompt) {
+                return '';
+        }
+
+        if (typeof prompt === 'string') {
+                return prompt;
+        }
+
+        if (typeof prompt === 'object') {
+                if (typeof prompt.text === 'string' && prompt.text.trim() !== '') {
+                        return prompt.text;
+                }
+
+                if (typeof prompt.prompt === 'string' && prompt.prompt.trim() !== '') {
+                        return prompt.prompt;
+                }
+
+                try {
+                        return JSON.stringify(prompt);
+                } catch (e) {
+                        return '';
+                }
+        }
+
+        return '';
+}
+
+function buildGalleryImageData(image, fallbackIndex) {
+        if (!image) {
+                return null;
+        }
+
+        const rawUrl = image.image_url || image.url || '';
+        const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+
+        if (!url) {
+                return null;
+        }
+
+        const promptText = normalizePromptValue(image.prompt);
+        const altText = promptText || (image.image_number ? `Image ${image.image_number}` : `Image ${fallbackIndex + 1}`);
+
+        return {
+                url,
+                alt: altText,
+                prompt: promptText,
+                displayName: image.display_name || '',
+                userLogo: image.user_logo || '',
+                userId: image.user_id || '',
+                format: image.format || '',
+                jobId: image.job_id || image.jobId || '',
+                taskId: image.task_id || image.taskId || '',
+        };
+}
+
+function applyOptionalAttribute($element, attribute, value) {
+        if (!$element || !$element.length) {
+                return;
+        }
+
+        if (typeof value === 'string' && value.length > 0) {
+                $element.attr(attribute, value);
+        } else {
+                $element.removeAttr(attribute);
+        }
+}
+
+function setPreviewImageFromData($imageElement, imageData) {
+        if (!$imageElement || !$imageElement.length) {
+                return;
+        }
+
+        if (!imageData || !imageData.url) {
+                $imageElement
+                        .attr('src', PLACEHOLDER_IMAGE_SRC)
+                        .attr('alt', "Image d'attente")
+                        .removeClass('preview-enlarge');
+
+                ['data-format-image', 'data-prompt', 'data-display_name', 'data-user-logo', 'data-user-id', 'data-job-id', 'data-task-id'].forEach(
+                        attribute => {
+                                $imageElement.removeAttr(attribute);
+                        }
+                );
+
+                return;
+        }
+
+        $imageElement
+                .attr('src', imageData.url)
+                .attr('alt', imageData.alt || 'Image générée')
+                .addClass('preview-enlarge');
+
+        applyOptionalAttribute($imageElement, 'data-format-image', imageData.format || '');
+        applyOptionalAttribute($imageElement, 'data-prompt', imageData.prompt || '');
+        applyOptionalAttribute($imageElement, 'data-display_name', imageData.displayName || '');
+        applyOptionalAttribute($imageElement, 'data-user-logo', imageData.userLogo || '');
+        applyOptionalAttribute($imageElement, 'data-user-id', imageData.userId || '');
+        applyOptionalAttribute($imageElement, 'data-job-id', imageData.jobId || '');
+        applyOptionalAttribute($imageElement, 'data-task-id', imageData.taskId || '');
+}
+
+function createPlaceholderThumbnail(index) {
+        const button = jQuery('<button>', {
+                type: 'button',
+                class: 'image-container generation-thumbnail is-placeholder',
+                'data-thumbnail-index': index,
+                'aria-label': `Miniature ${index + 1}`,
+        });
+
+        const image = jQuery('<img>', {
+                src: PLACEHOLDER_IMAGE_SRC,
+                alt: "Image d'attente",
+        });
+
+        button.append(image);
+        return button;
+}
+
+function createThumbnailFromData(imageData, index) {
+        const button = jQuery('<button>', {
+                type: 'button',
+                class: 'image-container generation-thumbnail',
+                'data-thumbnail-index': index,
+                'aria-label': imageData.alt || `Miniature ${index + 1}`,
+        });
+
+        const image = jQuery('<img>', {
+                src: imageData.url,
+                alt: imageData.alt || 'Image générée',
+        });
+
+        button.data('imageData', imageData);
+        button.append(image);
+
+        return button;
+}
+
+function renderGenerationGallery(images) {
+        const previewImage = jQuery('#generation-preview-image');
+        const thumbnailsContainer = jQuery('#content-images .generation-thumbnails');
+
+        if (!previewImage.length || !thumbnailsContainer.length) {
+                return false;
+        }
+
+        const normalizedImages = Array.isArray(images)
+                ? images
+                                .map((image, index) => buildGalleryImageData(image, index))
+                                .filter(Boolean)
+                : [];
+
+        thumbnailsContainer.empty();
+
+        if (normalizedImages.length === 0) {
+                setPreviewImageFromData(previewImage, null);
+
+                for (let i = 0; i < GENERATION_THUMBNAIL_LIMIT; i++) {
+                        thumbnailsContainer.append(createPlaceholderThumbnail(i));
+                }
+
+                return true;
+        }
+
+        const primaryImage = normalizedImages[0];
+        setPreviewImageFromData(previewImage, primaryImage);
+
+        const remainingImages = normalizedImages.slice(1, GENERATION_THUMBNAIL_LIMIT + 1);
+
+        remainingImages.forEach((imageData, idx) => {
+                thumbnailsContainer.append(createThumbnailFromData(imageData, idx));
+        });
+
+        for (let i = remainingImages.length; i < GENERATION_THUMBNAIL_LIMIT; i++) {
+                thumbnailsContainer.append(createPlaceholderThumbnail(i));
+        }
+
+        if (typeof adjustImageHeight === 'function') {
+                adjustImageHeight();
+        }
+
+        if (typeof enableImageEnlargement === 'function') {
+                enableImageEnlargement();
+        }
+
+        return true;
+}
 
 jQuery(document).ready(function() {
 	// Requête AJAX pour récupérer les images
@@ -32,15 +221,27 @@ function loadImages() {
 }
 
 function displayImages() {
+        const thumbnailsContainer = jQuery('#content-images .generation-thumbnails');
+        const filteredImages = allImages.filter(function(image) {
+                return image.format === selectedRatio;
+        });
+
+        if (thumbnailsContainer.length) {
+                const imagesToRender = filteredImages.length > 0 ? filteredImages.slice() : [];
+
+                if (imagesToRender.length > 1) {
+                        shuffleArray(imagesToRender);
+                }
+
+                renderGenerationGallery(imagesToRender.slice(0, 4));
+                return;
+        }
+
         var gridContainer = jQuery('#content-images .image-grid');
         var singlePreview = jQuery('#generation-preview-image');
 
-        var filteredImages = allImages.filter(function(image) {
-                return image.format === selectedRatio; // Filtrer les images selon le ratio global
-        });
-
         if (gridContainer.length) {
-                gridContainer.empty(); // Nettoyer la grille avant d'ajouter de nouvelles images
+                gridContainer.empty();
 
                 if (filteredImages.length === 0) {
                         for (var i = 0; i < 4; i++) {
@@ -59,9 +260,7 @@ function displayImages() {
                         shuffleArray(filteredImages);
 
                         filteredImages.slice(0, 4).forEach(function(image, index) {
-                                const promptText = typeof image.prompt === 'object'
-                                        ? (image.prompt.text || image.prompt.prompt || JSON.stringify(image.prompt))
-                                        : (image.prompt || '');
+                                const promptText = normalizePromptValue(image.prompt);
 
                                 var imgElement = jQuery('<img>')
                                         .attr('src', image.image_url)
@@ -96,9 +295,7 @@ function displayImages() {
                                 .removeAttr('data-prompt');
                 } else {
                         const image = filteredImages[0];
-                        const promptText = typeof image.prompt === 'object'
-                                ? (image.prompt.text || image.prompt.prompt || JSON.stringify(image.prompt))
-                                : (image.prompt || '');
+                        const promptText = normalizePromptValue(image.prompt);
 
                         targetImage
                                 .attr('src', image.image_url)
@@ -120,11 +317,44 @@ function displayImages() {
 
 
 function shuffleArray(array) {
-	for (let i = array.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1));
-		[array[i], array[j]] = [array[j], array[i]]; // Échange les éléments
-	}
+        for (let i = array.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [array[i], array[j]] = [array[j], array[i]]; // Échange les éléments
+        }
 }
+
+jQuery(document).on('click', '.generation-thumbnail', function(event) {
+        const button = jQuery(this);
+
+        if (button.hasClass('is-placeholder')) {
+                return;
+        }
+
+        const imageData = button.data('imageData');
+        if (!imageData || !imageData.url) {
+                return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const previewImage = jQuery('#generation-preview-image');
+        if (!previewImage.length) {
+                return;
+        }
+
+        setPreviewImageFromData(previewImage, imageData);
+
+        button.addClass('is-active').siblings('.generation-thumbnail').removeClass('is-active');
+
+        if (typeof adjustImageHeight === 'function') {
+                adjustImageHeight();
+        }
+
+        if (typeof enableImageEnlargement === 'function') {
+                enableImageEnlargement();
+        }
+});
 
 function displayImagesForCurrentUser() {
 	var mainContent = jQuery('#user_images');

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -139,8 +139,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     min-height: 0;
     width: 100%;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
+    gap: 24px;
     padding: 0 8px;
     box-sizing: border-box;
 }
@@ -150,18 +151,14 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-rows: repeat(2, minmax(0, 1fr));
-    gap: 16px;
-    width: min(100%, calc(100dvh - var(--header-height, 88px) - 120px));
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: min(180px, 100%);
     max-width: 100%;
     min-height: 0;
-    aspect-ratio: 1 / 1;
     height: auto;
-    max-height: 100%;
-    margin: 0 auto;
-    align-content: stretch;
+    margin: 0;
     align-items: stretch;
 }
 
@@ -810,7 +807,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .generation-preview {
-    display: none;
+    display: flex;
     width: min(100%, calc(100dvh - var(--header-height, 88px) - 120px));
     max-width: min(100%, 1080px);
     aspect-ratio: 1 / 1;
@@ -829,7 +826,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .generation-preview.is-active {
-    display: flex;
+    box-shadow: 0 0 0 2px rgba(43, 216, 121, 0.4);
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -860,6 +857,64 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     width: 100%;
     height: 100%;
     object-fit: contain;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-thumbnails {
+    flex: 0 0 auto;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-thumbnail {
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-thumbnail.is-placeholder {
+    cursor: default;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-thumbnail.is-active {
+    box-shadow: 0 0 0 2px rgba(43, 216, 121, 0.6);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-thumbnail:focus-visible {
+    outline: 2px solid var(--color-brand-400, #2bd879);
+    outline-offset: 2px;
+}
+
+@media (max-width: 1024px) {
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .grid-wrapper {
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .image-grid {
+        flex-direction: row;
+        justify-content: center;
+        width: 100%;
+    }
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images::-webkit-scrollbar {

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -61,29 +61,26 @@
                 </div>
         </section>
 
-        <div class="grid-wrapper" id="image-grid-wrapper">
-                <div id="image-grid" class="image-grid">
-                        <div class="image-container top">
-                                <img class="top" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 0" />
-                        </div>
-                        <div class="image-container top">
-                                <img class="top" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 1" />
-                        </div>
-                        <div class="image-container bottom">
-                                <img class="bottom" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 2" />
-                        </div>
-                        <div class="image-container bottom">
-                                <img class="bottom" src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image 3" />
-                        </div>
-                </div>
-        </div>
+       <div class="grid-wrapper generation-display" id="image-grid-wrapper">
+               <div id="generation-preview" class="generation-preview">
+                       <img
+                               id="generation-preview-image"
+                               class="centered-image"
+                               src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png"
+                               alt="Image d'attente"
+                       />
+               </div>
 
-        <div id="generation-preview" class="generation-preview">
-                <img
-                        id="generation-preview-image"
-                        class="centered-image"
-                        src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png"
-                        alt="Image d'attente"
-                />
-        </div>
+               <div id="image-grid" class="image-grid generation-thumbnails" role="list">
+                       <button type="button" class="image-container generation-thumbnail is-placeholder" data-thumbnail-index="0" aria-label="Miniature 1">
+                               <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                       </button>
+                       <button type="button" class="image-container generation-thumbnail is-placeholder" data-thumbnail-index="1" aria-label="Miniature 2">
+                               <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                       </button>
+                       <button type="button" class="image-container generation-thumbnail is-placeholder" data-thumbnail-index="2" aria-label="Miniature 3">
+                               <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                       </button>
+               </div>
+       </div>
 </div>


### PR DESCRIPTION
## Summary
- show the generated gallery as a large preview with three clickable thumbnails
- update the generation scripts to hydrate the preview and thumbnails for both saved and newly rendered images
- adjust the page styles to support the new split layout and responsive thumbnail strip

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daaa0fb0fc8322a3597188c34f537a