### PR TITLE
Display generated gallery preview with thumbnails

### DIFF
--- a/js/generate/generate.js
+++ b/js/generate/generate.js
@@ -18,6 +18,7 @@ let loadingToggled = false;
 let lastKnownProgress = null;
 let lastKnownMessage = '';
 let clearStateTimeoutId = null;
+let previewGalleryImages = [];
 const PROGRESS_STORAGE_KEY = 'customiizerGenerationProgress';
 const PROGRESS_EVENT_NAME = 'customiizer:generation-progress-update';
 
@@ -29,6 +30,25 @@ jQuery(function($) {
         const inlineProgressWrapper = document.getElementById('generation-progress-inline-wrapper');
         const savedPromptText = localStorage.getItem('savedPromptText');
         const PLACEHOLDER_IMAGE_SRC = 'https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png';
+
+        const previewThumbnailsContainer = getPreviewThumbnailsContainer();
+        if (previewThumbnailsContainer) {
+                previewThumbnailsContainer.addEventListener('click', event => {
+                        const targetButton = event.target.closest('[data-preview-index]');
+                        if (!targetButton || targetButton.classList.contains('is-placeholder') || targetButton.disabled) {
+                                return;
+                        }
+
+                        const parsedIndex = Number(targetButton.dataset.previewIndex);
+                        if (!Number.isFinite(parsedIndex)) {
+                                return;
+                        }
+
+                        handleThumbnailSelection(parsedIndex);
+                });
+        }
+
+        resetPreviewGallery();
 
         function getPreviewImageElement() {
                 return document.getElementById('generation-preview-image');
@@ -57,6 +77,10 @@ jQuery(function($) {
 
         function getPreviewWrapper() {
                 return document.getElementById('generation-preview');
+        }
+
+        function getPreviewThumbnailsContainer() {
+                return document.getElementById('generation-preview-thumbnails');
         }
 
         function getGridContainer() {
@@ -121,6 +145,7 @@ jQuery(function($) {
                         return;
                 }
 
+                resetPreviewGallery();
                 togglePreviewMode(true);
                 clearPreviewImageDatasets(previewImage);
                 previewImage.src = PLACEHOLDER_IMAGE_SRC;
@@ -144,6 +169,154 @@ jQuery(function($) {
                 if (imageElement.dataset && imageElement.dataset.livePreviewUrl) {
                         delete imageElement.dataset.livePreviewUrl;
                 }
+        }
+
+        function resetPreviewGallery() {
+                const thumbnailsContainer = getPreviewThumbnailsContainer();
+                previewGalleryImages = [];
+
+                if (!thumbnailsContainer) {
+                        return;
+                }
+
+                thumbnailsContainer.innerHTML = '';
+
+                for (let i = 0; i < 3; i++) {
+                        const placeholderButton = document.createElement('button');
+                        placeholderButton.type = 'button';
+                        placeholderButton.className = 'generation-preview__thumbnail is-placeholder';
+                        placeholderButton.disabled = true;
+
+                        const placeholderImage = document.createElement('img');
+                        placeholderImage.src = PLACEHOLDER_IMAGE_SRC;
+                        placeholderImage.alt = "Image d'attente";
+
+                        placeholderButton.appendChild(placeholderImage);
+                        thumbnailsContainer.appendChild(placeholderButton);
+                }
+        }
+
+        function applyImageMetaToElement(imageElement, imageData) {
+                if (!imageElement || !imageData || typeof imageData.url !== 'string') {
+                        return;
+                }
+
+                clearPreviewImageDatasets(imageElement);
+
+                imageElement.src = imageData.url;
+                imageElement.alt = imageData.prompt || 'Image générée';
+
+                if (imageElement.dataset) {
+                        imageElement.dataset.jobId = imageData.jobId || '';
+                        imageElement.dataset.taskId = imageData.taskId || '';
+                        imageElement.dataset.formatImage = imageData.formatImage || '';
+                        imageElement.dataset.prompt = imageData.prompt || prompt;
+                }
+
+                imageElement.setAttribute('data-display_name', imageData.display_name || '');
+                imageElement.setAttribute('data-user-logo', imageData.user_logo || '');
+                imageElement.setAttribute('data-user-id', imageData.user_id || '');
+        }
+
+        function renderPreviewGallery() {
+                const thumbnailsContainer = getPreviewThumbnailsContainer();
+                const previewImage = getPreviewImageElement();
+
+                if (!thumbnailsContainer || !previewImage) {
+                        return;
+                }
+
+                if (!Array.isArray(previewGalleryImages) || previewGalleryImages.length === 0) {
+                        resetPreviewGallery();
+                        clearPreviewImageDatasets(previewImage);
+                        previewImage.src = PLACEHOLDER_IMAGE_SRC;
+                        previewImage.alt = "Image d'attente";
+                        previewImage.classList.remove('preview-enlarge');
+                        return;
+                }
+
+                const [mainImage, ...thumbnailImages] = previewGalleryImages;
+                applyImageMetaToElement(previewImage, mainImage);
+                previewImage.classList.remove('preview-enlarge');
+
+                thumbnailsContainer.innerHTML = '';
+                const maxThumbnails = 3;
+                const renderedThumbnails = thumbnailImages.slice(0, maxThumbnails);
+
+                renderedThumbnails.forEach((imageData, index) => {
+                        const button = document.createElement('button');
+                        button.type = 'button';
+                        button.className = 'generation-preview__thumbnail';
+                        button.dataset.previewIndex = String(index + 1);
+                        button.setAttribute('aria-label', `Afficher l'image ${index + 2}`);
+
+                        const thumbImage = document.createElement('img');
+                        thumbImage.src = imageData.url;
+                        thumbImage.alt = imageData.prompt || `Miniature ${index + 2}`;
+
+                        button.appendChild(thumbImage);
+                        thumbnailsContainer.appendChild(button);
+                });
+
+                const placeholdersNeeded = Math.max(0, maxThumbnails - renderedThumbnails.length);
+                for (let i = 0; i < placeholdersNeeded; i++) {
+                        const placeholderButton = document.createElement('button');
+                        placeholderButton.type = 'button';
+                        placeholderButton.className = 'generation-preview__thumbnail is-placeholder';
+                        placeholderButton.disabled = true;
+
+                        const placeholderImage = document.createElement('img');
+                        placeholderImage.src = PLACEHOLDER_IMAGE_SRC;
+                        placeholderImage.alt = "Image d'attente";
+
+                        placeholderButton.appendChild(placeholderImage);
+                        thumbnailsContainer.appendChild(placeholderButton);
+                }
+        }
+
+        function populatePreviewGallery(images) {
+                if (!Array.isArray(images)) {
+                        previewGalleryImages = [];
+                        renderPreviewGallery();
+                        return;
+                }
+
+                const normalizedImages = images
+                        .filter(image => image && typeof image.url === 'string' && image.url.trim() !== '')
+                        .map(image => {
+                                const trimmedUrl = image.url.trim();
+                                return {
+                                        url: trimmedUrl,
+                                        prompt: image.prompt || prompt,
+                                        formatImage: image.format || '',
+                                        jobId: currentJobId || '',
+                                        taskId: currentTaskId || '',
+                                        display_name: image.display_name || '',
+                                        user_logo: image.user_logo || '',
+                                        user_id: image.user_id || '',
+                                };
+                        });
+
+                previewGalleryImages = normalizedImages.slice(0, 4);
+                renderPreviewGallery();
+        }
+
+        function handleThumbnailSelection(thumbnailIndex) {
+                if (!Array.isArray(previewGalleryImages) || previewGalleryImages.length === 0) {
+                        return;
+                }
+
+                if (typeof thumbnailIndex !== 'number' || thumbnailIndex <= 0 || thumbnailIndex >= previewGalleryImages.length) {
+                        return;
+                }
+
+                const [selectedImage] = previewGalleryImages.splice(thumbnailIndex, 1);
+                if (!selectedImage) {
+                        return;
+                }
+
+                previewGalleryImages.unshift(selectedImage);
+                renderPreviewGallery();
         }
 
         if (!validateButton || !customTextInput) {
@@ -398,15 +571,9 @@ jQuery(function($) {
                         return;
                 }
 
-                togglePreviewMode(false);
-
-                const previewImage = getPreviewImageElement();
-                if (previewImage) {
-                        clearPreviewImageDatasets(previewImage);
-                        previewImage.src = PLACEHOLDER_IMAGE_SRC;
-                        previewImage.alt = "Image d'attente";
-                        previewImage.classList.remove('preview-enlarge');
-                }
+                populatePreviewGallery(images);
+                togglePreviewMode(true);
+                closeProgressModal();
 
                 console.log(`${LOG_PREFIX} Images rendues`, { images });
         }
@@ -603,6 +770,7 @@ jQuery(function($) {
         function resetImageDisplay() {
                 ensureGridPlaceholders();
                 togglePreviewMode(false);
+                resetPreviewGallery();
 
                 const previewImage = getPreviewImageElement();
                 if (!previewImage) {

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -812,14 +812,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .generation-preview {
     display: none;
     width: 100%;
-    aspect-ratio: 1 / 1;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
-    position: relative;
-    overflow: hidden;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.04);
+    gap: 16px;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -832,11 +827,131 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout)
     > #content
     > .content-images
-    .generation-preview
+    .generation-preview__main {
+    flex: 1 1 auto;
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 0;
+    aspect-ratio: 1 / 1;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__main
     .centered-image {
     width: 100%;
     height: 100%;
     object-fit: contain;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnails {
+    width: 152px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail {
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.02);
+    padding: 0;
+    cursor: pointer;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+    min-height: 0;
+    aspect-ratio: 1 / 1;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail:focus-visible {
+    outline: 2px solid var(--color-brand-400, #2bd879);
+    outline-offset: 2px;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail:hover {
+    transform: scale(1.02);
+    border-color: rgba(255, 255, 255, 0.16);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail.is-placeholder {
+    cursor: default;
+    opacity: 0.4;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__thumbnail.is-placeholder:hover {
+    transform: none;
+    border-color: rgba(255, 255, 255, 0.04);
+}
+
+@media (max-width: 1200px) {
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .generation-preview__thumbnails {
+        width: 132px;
+    }
+}
+
+@media (max-width: 960px) {
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .generation-preview.is-active {
+        flex-direction: column;
+    }
+
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .generation-preview__thumbnails {
+        width: 100%;
+        flex-direction: row;
+    }
+
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .generation-preview__thumbnail {
+        flex: 1 1 0;
+    }
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .image-grid .image-container {

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -79,11 +79,24 @@
         </div>
 
         <div id="generation-preview" class="generation-preview">
-                <img
-                        id="generation-preview-image"
-                        class="centered-image"
-                        src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png"
-                        alt="Image d'attente"
-                />
+                <div class="generation-preview__main">
+                        <img
+                                id="generation-preview-image"
+                                class="centered-image"
+                                src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png"
+                                alt="Image d'attente"
+                        />
+                </div>
+                <div id="generation-preview-thumbnails" class="generation-preview__thumbnails" aria-label="Variations générées">
+                        <button type="button" class="generation-preview__thumbnail is-placeholder" disabled>
+                                <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                        </button>
+                        <button type="button" class="generation-preview__thumbnail is-placeholder" disabled>
+                                <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                        </button>
+                        <button type="button" class="generation-preview__thumbnail is-placeholder" disabled>
+                                <img src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png" alt="Image d'attente" />
+                        </button>
+                </div>
         </div>
 </div>


### PR DESCRIPTION
## Summary
- render generated results in a preview gallery with a main image and selectable thumbnails
- style the preview layout to match the theme and behave responsively
- update the generation workflow to populate the gallery and hide the loading indicator once complete

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dab7a2bb408322b0216cd5ca95fbf2