### PR TITLE
Limit configurateur full-width layout adjustments to product page

### DIFF
--- a/styles/product.css
+++ b/styles/product.css
@@ -8,6 +8,13 @@ body {
     overflow: hidden; /* Empêche le scroll sur la page produit */
 }
 
+body.configurator-page #site-content,
+body.configurator-page .site-content {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+}
+
 
 .product-section-label {
     margin: 0 0 6px;

--- a/templates/customize.php
+++ b/templates/customize.php
@@ -36,10 +36,11 @@ function load_main_content() {
 
 $path = $_SERVER['REQUEST_URI'];
 $is_customiize_page = strpos($path, '/customiize') !== false;
+$is_configurator_page = strpos($path, '/configurateur') !== false;
 $is_hub_layout = (
         !$is_customiize_page && (
                 strpos($path, '/v2shop') !== false ||
-                strpos($path, '/configurateur') !== false ||
+                $is_configurator_page ||
                 strpos($path, '/boutique') !== false ||
                 strpos($path, '/mycreation') !== false
         )
@@ -52,6 +53,9 @@ if ($is_customiize_page) {
 if ($is_hub_layout) {
         $body_classes[] = 'customize-layout-page';
         $body_classes[] = 'hub-layout-page';
+}
+if ($is_configurator_page) {
+        $body_classes[] = 'configurator-page';
 }
 
 $main_classes = [];


### PR DESCRIPTION
## Summary
- add a dedicated configurator body class when rendering the hub layout template
- scope the full-width override in product.css to the configurateur page only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadb39d9e48322bf5d75e1eecefe78