### PR TITLE
Adjust configurator product content width

### DIFF
--- a/styles/product.css
+++ b/styles/product.css
@@ -8,6 +8,14 @@ body {
     overflow: hidden; /* Empêche le scroll sur la page produit */
 }
 
+body.configurator-page #content,
+body.configurator-page #customize-main.hub-layout > #content {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    flex: 1 1 100%;
+}
+
 
 .product-section-label {
     margin: 0 0 6px;

--- a/templates/customize.php
+++ b/templates/customize.php
@@ -36,10 +36,11 @@ function load_main_content() {
 
 $path = $_SERVER['REQUEST_URI'];
 $is_customiize_page = strpos($path, '/customiize') !== false;
+$is_configurator_page = strpos($path, '/configurateur') !== false;
 $is_hub_layout = (
         !$is_customiize_page && (
                 strpos($path, '/v2shop') !== false ||
-                strpos($path, '/configurateur') !== false ||
+                $is_configurator_page ||
                 strpos($path, '/boutique') !== false ||
                 strpos($path, '/mycreation') !== false
         )
@@ -52,6 +53,9 @@ if ($is_customiize_page) {
 if ($is_hub_layout) {
         $body_classes[] = 'customize-layout-page';
         $body_classes[] = 'hub-layout-page';
+}
+if ($is_configurator_page) {
+        $body_classes[] = 'configurator-page';
 }
 
 $main_classes = [];


### PR DESCRIPTION
## Summary
- target the configurator product page content container so it spans the full width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadb39d9e48322bf5d75e1eecefe78