### PR TITLE
Center generation preview progress overlay

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -95,27 +95,31 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 }
 
 #customize-main.customize-layout:not(.hub-layout) #generation-progress-inline-wrapper {
+    position: absolute;
+    inset: 0;
     display: none;
-    width: 100%;
-    padding: 0 8px;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(12px, 4vw, 32px);
     box-sizing: border-box;
+    pointer-events: none;
+    z-index: 2;
 }
 
 #customize-main.customize-layout:not(.hub-layout) #generation-progress-inline-wrapper.is-active {
     display: flex;
-    justify-content: center;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
     #generation-progress-inline-wrapper
     .generation-progress-modal.inline-mode {
-    position: static;
+    position: relative;
     right: auto;
     bottom: auto;
-    max-width: min(520px, 100%);
-    width: 100%;
+    width: min(360px, 90%);
+    max-width: 100%;
     pointer-events: auto;
-    z-index: auto;
+    z-index: 1;
     align-items: stretch;
     justify-content: center;
 }
@@ -132,6 +136,13 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     .loading-container {
     box-shadow: none;
     background: rgba(18, 18, 18, 0.88);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    #generation-progress-inline-wrapper
+    .generation-progress-dialog.inline-mode
+    .loading-text {
+    text-align: center;
 }
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .grid-wrapper {
@@ -815,6 +826,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     align-items: stretch;
     justify-content: center;
     gap: 16px;
+    flex: 1 1 auto;
+    max-height: min(100%, max(280px, calc(100dvh - var(--header-height, 88px) - 120px)));
+    min-height: 0;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -828,7 +842,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .generation-preview__main {
-    flex: 1 1 auto;
+    flex: 1 1 0;
     position: relative;
     overflow: hidden;
     border-radius: 16px;
@@ -839,6 +853,8 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     justify-content: center;
     min-height: 0;
     aspect-ratio: 1 / 1;
+    max-height: 100%;
+    height: 100%;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -859,6 +875,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    flex: 0 0 152px;
+    max-height: 100%;
+    overflow: auto;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -948,9 +967,21 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     #customize-main.customize-layout:not(.hub-layout)
         > #content
         > .content-images
+        .generation-preview__main {
+        width: 100%;
+        max-height: none;
+        aspect-ratio: 1 / 1;
+        height: auto;
+    }
+
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
         .generation-preview__thumbnails {
         width: 100%;
         flex-direction: row;
+        max-height: none;
+        overflow: visible;
     }
 
     #customize-main.customize-layout:not(.hub-layout)

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -10,8 +10,6 @@
 -->
 
 <div class="content-images" id="content-images">
-        <div id="generation-progress-inline-wrapper" class="generation-progress-inline-wrapper" role="region" aria-live="polite" aria-hidden="true"></div>
-
         <section
                 id="variant-display"
                 class="variant-display is-hidden"
@@ -80,6 +78,13 @@
 
         <div id="generation-preview" class="generation-preview">
                 <div class="generation-preview__main">
+                        <div
+                                id="generation-progress-inline-wrapper"
+                                class="generation-progress-inline-wrapper"
+                                role="region"
+                                aria-live="polite"
+                                aria-hidden="true"
+                        ></div>
                         <img
                                 id="generation-preview-image"
                                 class="centered-image"


### PR DESCRIPTION
## Summary
- move the inline progress wrapper inside the generation preview to anchor the loading bar over the main image
- update preview layout styles so the preview area respects its container height and the progress modal is centered over the image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db19e771788322871825db22331007