### PR TITLE
Center generation preview image vertically

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -823,7 +823,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .generation-preview {
     display: none;
     width: 100%;
-    align-items: stretch;
+    align-items: center;
     justify-content: center;
     gap: 16px;
     flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- align the generation preview container content vertically so the main image sits in the middle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db1fb914988322992d398b1a2dbb59