### PR TITLE
Fetch job images when generation completes

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -915,6 +915,14 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout)
     > #content
     > .content-images
+    .generation-preview__thumbnail.is-selected {
+    border-color: var(--color-brand-400, #2bd879);
+    box-shadow: 0 0 0 2px rgba(43, 216, 121, 0.2);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
     .generation-preview__thumbnail:focus-visible {
     outline: 2px solid var(--color-brand-400, #2bd879);
     outline-offset: 2px;


### PR DESCRIPTION
## Summary
- add a reusable normalizer for generated image rows and expose an AJAX action to fetch all images for a job
- update the generation polling flow to treat the "done" status as complete, retrieve the job images, and render them once they arrive
- finalize the UI only after successfully rendering the fetched images so the gallery displays every result

## Testing
- php -l includes/image_status.php

------
https://chatgpt.com/codex/tasks/task_e_68dbac86c08c8322885fd7fccb8c744c