### PR TITLE
Fix generator ratio selection sync

### DIFF
--- a/js/generate/show_ratio.js
+++ b/js/generate/show_ratio.js
@@ -11,6 +11,7 @@ let ratioFromQuery = '';
 document.addEventListener('DOMContentLoaded', function () {
     ratioFromQuery = getRatioFromQueryParam();
     setDefaultSelectedInfo();
+    syncSelectedRatio();
     loadProductData();
 });
 
@@ -136,8 +137,13 @@ function setDefaultSelectedInfo() {
     updateVariantSummaryImage(DEFAULT_SUMMARY_IMAGE);
 }
 
+function syncSelectedRatio() {
+    window.selectedRatio = selectedRatio;
+}
+
 function clearSelectedVariantState() {
     selectedRatio = '';
+    syncSelectedRatio();
 
     if (typeof selectedVariant !== 'undefined') {
         selectedVariant = null;
@@ -155,6 +161,7 @@ function clearSelectedVariantState() {
 function resetVariantSelection() {
     selectedProductKey = '';
     selectedRatio = DEFAULT_RATIO;
+    syncSelectedRatio();
 
     if (typeof selectedVariant !== 'undefined') {
         selectedVariant = null;
@@ -518,6 +525,7 @@ function handleVariantSelection(element, variant, options = {}) {
 
     const ratioValue = (variant.ratio_image || '').trim();
     selectedRatio = ratioValue;
+    syncSelectedRatio();
     selectedProductKey = normalizeProductName(variant.product_name);
 
     if (typeof selectedVariant !== 'undefined') {


### PR DESCRIPTION
## Summary
- ensure the selected ratio used for generation is kept in sync with the global window state
- initialise the global ratio value on load so the generator recognises a picked product

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe094fd688322a7195eb9fc6cc3e3