### PR TITLE
Add detailed logging for Customiize image generation

### DIFF
--- a/includes/proxy/generate_image.php
+++ b/includes/proxy/generate_image.php
@@ -10,6 +10,7 @@ require_once dirname(__DIR__, 2) . '/utilities.php';
 header('Content-Type: application/json; charset=utf-8');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    customiizer_log('generate_image', 'Requête rejetée : méthode non autorisée (' . $_SERVER['REQUEST_METHOD'] . ')');
     http_response_code(405);
     echo wp_json_encode([
         'success' => false,
@@ -18,9 +19,16 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit;
 }
 
-$payload = json_decode(file_get_contents('php://input'), true);
+$rawInput = file_get_contents('php://input');
+if ($rawInput === false) {
+    $rawInput = '';
+}
+customiizer_log('generate_image', 'Requête brute reçue : ' . substr($rawInput, 0, 500));
+
+$payload = json_decode($rawInput, true);
 
 if (json_last_error() !== JSON_ERROR_NONE) {
+    customiizer_log('generate_image', 'Requête JSON invalide : ' . json_last_error_msg());
     http_response_code(400);
     echo wp_json_encode([
         'success' => false,
@@ -30,6 +38,7 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 }
 
 if (!is_user_logged_in()) {
+    customiizer_log('generate_image', 'Requête refusée : utilisateur non authentifié');
     http_response_code(401);
     echo wp_json_encode([
         'success' => false,
@@ -42,6 +51,7 @@ $prompt = isset($payload['prompt']) ? trim(wp_unslash($payload['prompt'])) : '';
 $formatImage = isset($payload['format_image']) ? sanitize_text_field($payload['format_image']) : '';
 
 if ($prompt === '') {
+    customiizer_log('generate_image', 'Requête invalide : prompt manquant');
     http_response_code(400);
     echo wp_json_encode([
         'success' => false,
@@ -51,6 +61,7 @@ if ($prompt === '') {
 }
 
 if ($formatImage === '') {
+    customiizer_log('generate_image', "Requête invalide : format d'image manquant");
     http_response_code(400);
     echo wp_json_encode([
         'success' => false,
@@ -62,6 +73,22 @@ if ($formatImage === '') {
 $userId = get_current_user_id();
 $taskId = uniqid('task_', true);
 $now = current_time('mysql');
+
+$promptLength = strlen($prompt);
+$promptPreview = function_exists('mb_substr') ? mb_substr($prompt, 0, 120, 'UTF-8') : substr($prompt, 0, 120);
+if ($promptLength > 120) {
+    $promptPreview .= '…';
+}
+
+$logContextData = [
+    'userId' => $userId,
+    'taskId' => $taskId,
+    'promptLength' => $promptLength,
+    'promptPreview' => $promptPreview,
+    'formatImage' => $formatImage,
+];
+
+customiizer_log('generate_image', 'Requête validée : ' . wp_json_encode($logContextData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
 
 global $wpdb;
 $customPrefix = 'WPC_';
@@ -92,6 +119,7 @@ if ($inserted === false) {
 }
 
 $jobId = (int) $wpdb->insert_id;
+customiizer_log('generate_image', sprintf('Job inséré (ID %d) pour la tâche %s', $jobId, $taskId));
 
 $queueName = defined('RABBIT_IMAGE_QUEUE') ? RABBIT_IMAGE_QUEUE : 'image_jobs_dev';
 
@@ -123,6 +151,7 @@ try {
     $channel->basic_publish($message, '', $queueName);
     $channel->close();
     $connection->close();
+    customiizer_log('generate_image', sprintf('Message RabbitMQ publié sur %s pour job %d', $queueName, $jobId));
 } catch (Throwable $exception) {
     customiizer_log('generate_image', 'Erreur RabbitMQ : ' . $exception->getMessage());
     $wpdb->update(


### PR DESCRIPTION
## Summary
- add defensive logging on the generate_image proxy endpoint for request validation, job creation and RabbitMQ publishing
- expand frontend console logs around the Customiize image generation workflow to capture request and response details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2b98b770832286ec07de753ffc5c