### PR TITLE
Normalize image prefixes and sync upscale counts

### DIFF
--- a/api/images/save.php
+++ b/api/images/save.php
@@ -66,7 +66,7 @@ function save_generated_image(WP_REST_Request $request) {
                 ], 200);
         }
 
-        $position = intval($request->get_param('position'));
+        $positionRaw = $request->get_param('position');
         $prompt = $request->get_param('prompt');
         $format = $request->get_param('format_image');
         $settingsParam = $request->get_param('settings');
@@ -99,8 +99,24 @@ function save_generated_image(WP_REST_Request $request) {
                 'image_date' => current_time('mysql'),
         ];
 
-        if ($position > 0) {
-                $imageData['image_prefix'] = $position;
+        $normalizedPosition = '';
+
+        if ($positionRaw !== null && $positionRaw !== '') {
+                $sanitizedPosition = sanitize_text_field($positionRaw);
+
+                if (preg_match('/^choice_\d+$/', $sanitizedPosition)) {
+                        $normalizedPosition = $sanitizedPosition;
+                } else {
+                        $position = (int) $sanitizedPosition;
+
+                        if ($position > 0) {
+                                $normalizedPosition = sprintf('choice_%d', $position);
+                        }
+                }
+        }
+
+        if ($normalizedPosition !== '') {
+                $imageData['image_prefix'] = $normalizedPosition;
         }
 
         if ($sourceId !== null) {

--- a/includes/image_status.php
+++ b/includes/image_status.php
@@ -60,8 +60,9 @@ function check_image_status() {
     $progressValue = is_numeric($rawProgress) ? (float) $rawProgress : null;
 
     $upscaleCount = 0;
+    $upscaleColumnFilled = array_key_exists('upscale_done', $job) && $job['upscale_done'] !== null;
 
-    if (array_key_exists('upscale_done', $job) && $job['upscale_done'] !== null) {
+    if ($upscaleColumnFilled) {
         $upscaleCount = (int) $job['upscale_done'];
     } else {
         $choicePrefix = $wpdb->esc_like('choice_') . '%';
@@ -74,6 +75,15 @@ function check_image_status() {
         $upscaleResult = $wpdb->get_var($upscaleQuery);
         if ($upscaleResult !== null) {
             $upscaleCount = (int) $upscaleResult;
+            if ($upscaleCount > 0) {
+                $wpdb->update(
+                    $jobsTable,
+                    ['upscale_done' => $upscaleCount],
+                    ['id' => (int) $job['id']],
+                    ['%d'],
+                    ['%d']
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- normalize saved image prefixes to the `choice_%` format without double-prefixing existing values
- persist the fallback upscale count in `check_image_status` when the job record has no value

## Testing
- php -l api/images/save.php
- php -l includes/image_status.php

------
https://chatgpt.com/codex/tasks/task_e_68dc3e6be56083229eac039c4509639c