### PR TITLE
Refactor image generation pipeline

### DIFF
--- a/api/images/save.php
+++ b/api/images/save.php
@@ -9,6 +9,14 @@ register_rest_route('api/v1/images', '/save', [
 function save_generated_image(WP_REST_Request $request) {
         global $wpdb;
 
+        if (!function_exists('customiizer_get_generation_tables')) {
+                require_once get_stylesheet_directory() . '/includes/image_generation.php';
+        }
+
+        $tables = customiizer_get_generation_tables();
+        $jobsTable = $tables['jobs'];
+        $imagesTable = $tables['images'];
+
         $jobId = intval($request->get_param('job_id'));
         $taskId = sanitize_text_field($request->get_param('task_id'));
 
@@ -18,9 +26,6 @@ function save_generated_image(WP_REST_Request $request) {
                         'message' => 'job_id ou task_id requis'
                 ], 400);
         }
-
-        $customPrefix = 'WPC_';
-        $jobsTable = $customPrefix . 'generation_jobs';
 
         if ($jobId) {
                 $job = $wpdb->get_row(
@@ -41,7 +46,6 @@ function save_generated_image(WP_REST_Request $request) {
                 ], 404);
         }
 
-        $imagesTable = $customPrefix . 'generated_image';
         $imageUrl = esc_url_raw($request->get_param('image_url'));
 
         if (empty($imageUrl)) {

--- a/functions.php
+++ b/functions.php
@@ -121,6 +121,7 @@ add_action( 'init', function() {
 
         $includes = [
                 '/utilities.php',
+                '/includes/image_generation.php',
                 '/assets.php',
                 '/includes/azure.php',
 

--- a/includes/get_generated_images.php
+++ b/includes/get_generated_images.php
@@ -4,28 +4,21 @@
  * database.
  */
 function get_generated_images_ajax() {
-    global $wpdb;
-    $table_name = 'WPC_generated_image';
+    $images = customiizer_fetch_generated_images([
+        'order_by' => 'image_date',
+        'order'    => 'DESC',
+    ]);
 
-    // Récupérer toutes les images de la base de données
-    $results = $wpdb->get_results("SELECT * FROM $table_name");
-
-    // Vérification si des images sont trouvées
-    if (!empty($results)) {
-        // Envoyer une réponse JSON de succès avec les images
-        wp_send_json_success(array(
-            'images' => $results,
-            'message' => 'Images générées récupérées avec succès.'
-        ));
-    } else {
-        // Si aucune image n'est trouvée, renvoyer une réponse JSON d'erreur
-        wp_send_json_error(array(
-            'message' => 'Aucune image trouvée.'
-        ));
+    if (!empty($images)) {
+        wp_send_json_success([
+            'images'  => $images,
+            'message' => 'Images générées récupérées avec succès.',
+        ]);
     }
 
-    // Terminer la requête pour éviter tout output supplémentaire
-    wp_die();
+    wp_send_json_error([
+        'message' => 'Aucune image trouvée.'
+    ], 404);
 }
 
 add_action('wp_ajax_nopriv_get_generated_images', 'get_generated_images_ajax');

--- a/includes/image_generation.php
+++ b/includes/image_generation.php
@@ -1,0 +1,220 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Returns the prefix applied to custom image-generation tables.
+ *
+ * @return string
+ */
+function customiizer_get_custom_table_prefix() {
+    static $prefix = null;
+
+    if ($prefix === null) {
+        $prefix = 'WPC_';
+        $filtered = apply_filters('customiizer_custom_table_prefix', $prefix);
+
+        if (is_string($filtered) && $filtered !== '') {
+            $prefix = $filtered;
+        }
+    }
+
+    return $prefix;
+}
+
+/**
+ * Returns the database tables used for image generation.
+ *
+ * @return array{jobs: string, images: string}
+ */
+function customiizer_get_generation_tables() {
+    static $tables = null;
+
+    if ($tables === null) {
+        $prefix = customiizer_get_custom_table_prefix();
+        $tables = [
+            'jobs'   => $prefix . 'generation_jobs',
+            'images' => $prefix . 'generated_image',
+        ];
+    }
+
+    return $tables;
+}
+
+/**
+ * Decodes the JSON settings stored on a generated image row.
+ *
+ * @param mixed $value Raw value stored in the database.
+ *
+ * @return array<mixed>|string
+ */
+function customiizer_decode_settings($value) {
+    if ($value === '' || $value === null) {
+        return [];
+    }
+
+    $decoded = json_decode($value, true);
+    if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+        return $decoded;
+    }
+
+    return $value;
+}
+
+/**
+ * Normalizes a generated image row into a structured array consumed by the UI.
+ *
+ * @param array<string, mixed> $row
+ *
+ * @return array{id: int|null, jobId: int|null, url: string, format: string, prompt: string, prefix: string, settings: mixed}
+ */
+function customiizer_normalize_generated_image_row($row) {
+    return [
+        'id'       => isset($row['image_number']) ? (int) $row['image_number'] : null,
+        'jobId'    => isset($row['job_id']) ? (int) $row['job_id'] : null,
+        'url'      => $row['image_url'] ?? '',
+        'format'   => $row['format_image'] ?? '',
+        'prompt'   => $row['prompt'] ?? '',
+        'prefix'   => $row['image_prefix'] ?? '',
+        'settings' => customiizer_decode_settings($row['settings'] ?? ''),
+    ];
+}
+
+/**
+ * Retrieves generated images with optional filters.
+ *
+ * @param array<string, mixed> $args {
+ *     @type int|null    $user_id   Limit to a specific user.
+ *     @type int|null    $job_id    Limit to a specific job.
+ *     @type string|null $format    Limit to a specific format_image value.
+ *     @type string|null $date_from Lower bound date (inclusive, mysql datetime string).
+ *     @type string|null $date_to   Upper bound date (inclusive, mysql datetime string).
+ *     @type int|null    $limit     Maximum number of rows to return.
+ *     @type bool        $random    Whether the result should be randomised.
+ *     @type string      $order     Sort order (ASC or DESC).
+ *     @type string      $order_by  Column used to order results (whitelisted).
+ *     @type array<int, string> $fields Fields to select (defaults to a safe subset).
+ *     @type bool        $normalize Whether the results should be normalized with
+ *                                  {@see customiizer_normalize_generated_image_row}.
+ * }
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function customiizer_fetch_generated_images(array $args = []) {
+    global $wpdb;
+
+    $tables = customiizer_get_generation_tables();
+    $table  = $tables['images'];
+
+    $defaults = [
+        'user_id'   => null,
+        'job_id'    => null,
+        'format'    => null,
+        'date_from' => null,
+        'date_to'   => null,
+        'limit'     => null,
+        'random'    => false,
+        'order'     => 'DESC',
+        'order_by'  => 'image_date',
+        'fields'    => [
+            'image_number',
+            'user_id',
+            'user_login',
+            'upscaled_id',
+            'source_id',
+            'image_date',
+            'image_prefix',
+            'image_url',
+            'picture_likes_nb',
+            'format_image',
+            'prompt',
+            'settings',
+            'job_id',
+        ],
+        'normalize' => false,
+    ];
+
+    $args = wp_parse_args($args, $defaults);
+
+    $allowedOrderBy = ['image_date', 'image_number'];
+    $orderBy        = in_array($args['order_by'], $allowedOrderBy, true) ? $args['order_by'] : 'image_date';
+    $order          = strtoupper($args['order']) === 'ASC' ? 'ASC' : 'DESC';
+
+    $fields = $args['fields'];
+    if (!is_array($fields) || empty($fields)) {
+        $fields = $defaults['fields'];
+    }
+
+    $safeFields = [];
+    foreach ($fields as $field) {
+        if (is_string($field) && preg_match('/^[A-Za-z0-9_]+$/', $field)) {
+            $safeFields[] = $field;
+        }
+    }
+
+    if (empty($safeFields)) {
+        $safeFields = $defaults['fields'];
+    }
+
+    $select = implode(', ', $safeFields);
+
+    $where  = ['1 = 1'];
+    $values = [];
+
+    if (!empty($args['user_id'])) {
+        $where[]  = 'user_id = %d';
+        $values[] = (int) $args['user_id'];
+    }
+
+    if (!empty($args['job_id'])) {
+        $where[]  = 'job_id = %d';
+        $values[] = (int) $args['job_id'];
+    }
+
+    if (!empty($args['format'])) {
+        $where[]  = 'format_image = %s';
+        $values[] = sanitize_text_field($args['format']);
+    }
+
+    if (!empty($args['date_from'])) {
+        $where[]  = 'image_date >= %s';
+        $values[] = sanitize_text_field($args['date_from']);
+    }
+
+    if (!empty($args['date_to'])) {
+        $where[]  = 'image_date <= %s';
+        $values[] = sanitize_text_field($args['date_to']);
+    }
+
+    $sql = "SELECT {$select} FROM {$table} WHERE " . implode(' AND ', $where);
+
+    if ($args['random']) {
+        $sql .= ' ORDER BY RAND()';
+    } else {
+        $sql .= " ORDER BY {$orderBy} {$order}";
+    }
+
+    if (!empty($args['limit'])) {
+        $limit = max(1, (int) $args['limit']);
+        $sql  .= ' LIMIT %d';
+        $values[] = $limit;
+    }
+
+    if (!empty($values)) {
+        $sql = $wpdb->prepare($sql, $values);
+    }
+
+    $results = $wpdb->get_results($sql, ARRAY_A);
+
+    if (!$results) {
+        return [];
+    }
+
+    if (!empty($args['normalize'])) {
+        return array_map('customiizer_normalize_generated_image_row', $results);
+    }
+
+    return $results;
+}

--- a/includes/proxy/generate_image.php
+++ b/includes/proxy/generate_image.php
@@ -6,178 +6,239 @@ use PhpAmqpLib\Message\AMQPMessage;
 require_once dirname(__DIR__, 5) . '/wp-load.php';
 require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
 require_once dirname(__DIR__, 2) . '/utilities.php';
+require_once dirname(__DIR__) . '/image_generation.php';
 
 header('Content-Type: application/json; charset=utf-8');
 
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    customiizer_log('generate_image', 'Requête rejetée : méthode non autorisée (' . $_SERVER['REQUEST_METHOD'] . ')');
-    http_response_code(405);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => 'Méthode non autorisée.'
-    ]);
-    exit;
-}
+customiizer_proxy_require_post_request();
 
-$rawInput = file_get_contents('php://input');
-if ($rawInput === false) {
-    $rawInput = '';
-}
-customiizer_log('generate_image', 'Requête brute reçue : ' . substr($rawInput, 0, 500));
+$payload = customiizer_proxy_parse_json_body();
+$userId  = customiizer_proxy_require_authentication();
+[$prompt, $formatImage] = customiizer_proxy_validate_payload($payload);
 
-$payload = json_decode($rawInput, true);
+[$jobId, $taskId] = customiizer_proxy_create_job($userId, $prompt, $formatImage);
 
-if (json_last_error() !== JSON_ERROR_NONE) {
-    customiizer_log('generate_image', 'Requête JSON invalide : ' . json_last_error_msg());
-    http_response_code(400);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => 'Requête JSON invalide.'
-    ]);
-    exit;
-}
-
-if (!is_user_logged_in()) {
-    customiizer_log('generate_image', 'Requête refusée : utilisateur non authentifié');
-    http_response_code(401);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => 'Authentification requise.'
-    ]);
-    exit;
-}
-
-$prompt = isset($payload['prompt']) ? trim(wp_unslash($payload['prompt'])) : '';
-$formatImage = isset($payload['format_image']) ? sanitize_text_field($payload['format_image']) : '';
-
-if ($prompt === '') {
-    customiizer_log('generate_image', 'Requête invalide : prompt manquant');
-    http_response_code(400);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => 'Le prompt est obligatoire.'
-    ]);
-    exit;
-}
-
-if ($formatImage === '') {
-    customiizer_log('generate_image', "Requête invalide : format d'image manquant");
-    http_response_code(400);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => "Le format de l'image est obligatoire."
-    ]);
-    exit;
-}
-
-$userId = get_current_user_id();
-$taskId = uniqid('task_', true);
-$now = current_time('mysql');
-
-$promptLength = strlen($prompt);
-$promptPreview = function_exists('mb_substr') ? mb_substr($prompt, 0, 120, 'UTF-8') : substr($prompt, 0, 120);
-if ($promptLength > 120) {
-    $promptPreview .= '…';
-}
-
-$logContextData = [
-    'userId' => $userId,
-    'taskId' => $taskId,
-    'promptLength' => $promptLength,
-    'promptPreview' => $promptPreview,
+$messagePayload = [
+    'taskId'      => $taskId,
+    'jobId'       => $jobId,
+    'userId'      => $userId,
+    'prompt'      => $prompt,
     'formatImage' => $formatImage,
+    'format_image'=> $formatImage,
 ];
 
-customiizer_log('generate_image', 'Requête validée : ' . wp_json_encode($logContextData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
-
-global $wpdb;
-$customPrefix = 'WPC_';
-$jobsTable = $customPrefix . 'generation_jobs';
-
-$inserted = $wpdb->insert(
-    $jobsTable,
-    [
-        'task_id' => $taskId,
-        'user_id' => $userId,
-        'prompt' => $prompt,
-        'format_image' => $formatImage,
-        'status' => 'pending',
-        'created_at' => $now,
-        'updated_at' => $now,
-    ],
-    ['%s', '%d', '%s', '%s', '%s', '%s', '%s']
-);
-
-if ($inserted === false) {
-    customiizer_log('generate_image', 'Échec insertion job : ' . $wpdb->last_error);
-    http_response_code(500);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => "Impossible d'enregistrer la génération."
-    ]);
-    exit;
-}
-
-$jobId = (int) $wpdb->insert_id;
-customiizer_log('generate_image', sprintf('Job inséré (ID %d) pour la tâche %s', $jobId, $taskId));
-
 $queueName = defined('RABBIT_IMAGE_QUEUE') ? RABBIT_IMAGE_QUEUE : 'image_jobs_dev';
+$publishResult = customiizer_proxy_publish_job($messagePayload, $queueName);
 
-try {
-    $connection = new AMQPStreamConnection(
-        RABBIT_HOST,
-        RABBIT_PORT,
-        RABBIT_USER,
-        RABBIT_PASS
+if (is_wp_error($publishResult)) {
+    customiizer_log('generate_image', 'Erreur RabbitMQ : ' . $publishResult->get_error_message());
+    customiizer_proxy_mark_job_as_error($jobId);
+
+    wp_send_json_error(
+        ['message' => 'Impossible de programmer la génération pour le moment.'],
+        500
     );
-
-    $channel = $connection->channel();
-    $channel->queue_declare($queueName, false, true, false, false);
-
-    $messageBody = wp_json_encode([
-        'taskId' => $taskId,
-        'jobId' => $jobId,
-        'userId' => $userId,
-        'prompt' => $prompt,
-        'formatImage' => $formatImage,
-        'format_image' => $formatImage,
-    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-
-    $message = new AMQPMessage(
-        $messageBody,
-        ['delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT]
-    );
-
-    $channel->basic_publish($message, '', $queueName);
-    $channel->close();
-    $connection->close();
-    customiizer_log('generate_image', sprintf('Message RabbitMQ publié sur %s pour job %d', $queueName, $jobId));
-} catch (Throwable $exception) {
-    customiizer_log('generate_image', 'Erreur RabbitMQ : ' . $exception->getMessage());
-    $wpdb->update(
-        $jobsTable,
-        [
-            'status' => 'error',
-            'updated_at' => current_time('mysql'),
-        ],
-        ['id' => $jobId],
-        ['%s', '%s'],
-        ['%d']
-    );
-
-    http_response_code(500);
-    echo wp_json_encode([
-        'success' => false,
-        'message' => 'Impossible de programmer la génération pour le moment.'
-    ]);
-    exit;
 }
 
 customiizer_log('generate_image', sprintf('Job %s (%d) créé pour utilisateur %d', $taskId, $jobId, $userId));
 
-echo wp_json_encode([
-    'success' => true,
+wp_send_json_success([
     'taskId' => $taskId,
-    'status' => 'pending'
+    'status' => 'pending',
 ]);
 exit;
+
+function customiizer_proxy_require_post_request() {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        customiizer_log('generate_image', 'Requête rejetée : méthode non autorisée (' . $_SERVER['REQUEST_METHOD'] . ')');
+        wp_send_json_error(
+            ['message' => 'Méthode non autorisée.'],
+            405
+        );
+    }
+}
+
+function customiizer_proxy_parse_json_body() {
+    $rawInput = file_get_contents('php://input');
+    if ($rawInput === false) {
+        $rawInput = '';
+    }
+
+    customiizer_log('generate_image', 'Requête brute reçue : ' . substr($rawInput, 0, 500));
+
+    $payload = json_decode($rawInput, true);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($payload)) {
+        customiizer_log('generate_image', 'Requête JSON invalide : ' . json_last_error_msg());
+        wp_send_json_error(
+            ['message' => 'Requête JSON invalide.'],
+            400
+        );
+    }
+
+    return $payload;
+}
+
+function customiizer_proxy_require_authentication() {
+    if (!is_user_logged_in()) {
+        customiizer_log('generate_image', 'Requête refusée : utilisateur non authentifié');
+        wp_send_json_error(
+            ['message' => 'Authentification requise.'],
+            401
+        );
+    }
+
+    return get_current_user_id();
+}
+
+function customiizer_proxy_validate_payload(array $payload) {
+    $rawPrompt = isset($payload['prompt']) ? $payload['prompt'] : '';
+    $rawPrompt = is_string($rawPrompt) ? trim(wp_unslash($rawPrompt)) : '';
+
+    $rawFormat = isset($payload['format_image']) ? $payload['format_image'] : '';
+    $rawFormat = is_string($rawFormat) ? wp_unslash($rawFormat) : '';
+
+    if ($rawPrompt === '') {
+        customiizer_log('generate_image', 'Requête invalide : prompt manquant');
+        wp_send_json_error(
+            ['message' => 'Le prompt est obligatoire.'],
+            400
+        );
+    }
+
+    if ($rawFormat === '') {
+        customiizer_log('generate_image', "Requête invalide : format d'image manquant");
+        wp_send_json_error(
+            ['message' => "Le format de l'image est obligatoire."],
+            400
+        );
+    }
+
+    $prompt      = sanitize_textarea_field($rawPrompt);
+    $formatImage = sanitize_text_field($rawFormat);
+
+    return [$prompt, $formatImage];
+}
+
+function customiizer_proxy_create_job($userId, $prompt, $formatImage) {
+    global $wpdb;
+
+    $tables   = customiizer_get_generation_tables();
+    $jobsTable = $tables['jobs'];
+
+    $taskId = uniqid('task_', true);
+    $now    = current_time('mysql');
+
+    $logContext = customiizer_proxy_build_log_context($userId, $taskId, $prompt, $formatImage);
+    customiizer_log('generate_image', 'Requête validée : ' . wp_json_encode($logContext, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+    $inserted = $wpdb->insert(
+        $jobsTable,
+        [
+            'task_id'      => $taskId,
+            'user_id'      => $userId,
+            'prompt'       => $prompt,
+            'format_image' => $formatImage,
+            'status'       => 'pending',
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ],
+        ['%s', '%d', '%s', '%s', '%s', '%s', '%s']
+    );
+
+    if ($inserted === false) {
+        customiizer_log('generate_image', 'Échec insertion job : ' . $wpdb->last_error);
+        wp_send_json_error(
+            ['message' => "Impossible d'enregistrer la génération."],
+            500
+        );
+    }
+
+    $jobId = (int) $wpdb->insert_id;
+    customiizer_log('generate_image', sprintf('Job inséré (ID %d) pour la tâche %s', $jobId, $taskId));
+
+    return [$jobId, $taskId];
+}
+
+function customiizer_proxy_build_log_context($userId, $taskId, $prompt, $formatImage) {
+    $promptLength = function_exists('mb_strlen') ? mb_strlen($prompt, 'UTF-8') : strlen($prompt);
+    $promptPreview = function_exists('mb_substr') ? mb_substr($prompt, 0, 120, 'UTF-8') : substr($prompt, 0, 120);
+
+    if ($promptLength > 120) {
+        $promptPreview .= '…';
+    }
+
+    return [
+        'userId'       => $userId,
+        'taskId'       => $taskId,
+        'promptLength' => $promptLength,
+        'promptPreview'=> $promptPreview,
+        'formatImage'  => $formatImage,
+    ];
+}
+
+function customiizer_proxy_publish_job(array $messagePayload, $queueName) {
+    $connection = null;
+    $channel    = null;
+
+    try {
+        $connection = new AMQPStreamConnection(
+            RABBIT_HOST,
+            RABBIT_PORT,
+            RABBIT_USER,
+            RABBIT_PASS
+        );
+
+        $channel = $connection->channel();
+        $channel->queue_declare($queueName, false, true, false, false);
+
+        $messageBody = wp_json_encode($messagePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $message     = new AMQPMessage(
+            $messageBody,
+            ['delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT]
+        );
+
+        $channel->basic_publish($message, '', $queueName);
+        $channel->close();
+        $connection->close();
+
+        customiizer_log('generate_image', sprintf('Message RabbitMQ publié sur %s pour job %d', $queueName, $messagePayload['jobId']));
+
+        return true;
+    } catch (Throwable $exception) {
+        if ($channel && method_exists($channel, 'close')) {
+            try {
+                $channel->close();
+            } catch (Throwable $closeException) {
+                // Ignored on purpose.
+            }
+        }
+
+        if ($connection && method_exists($connection, 'close')) {
+            try {
+                $connection->close();
+            } catch (Throwable $closeException) {
+                // Ignored on purpose.
+            }
+        }
+
+        return new WP_Error('rabbitmq_error', $exception->getMessage());
+    }
+}
+
+function customiizer_proxy_mark_job_as_error($jobId) {
+    global $wpdb;
+
+    $tables    = customiizer_get_generation_tables();
+    $jobsTable = $tables['jobs'];
+
+    $wpdb->update(
+        $jobsTable,
+        [
+            'status'     => 'error',
+            'updated_at' => current_time('mysql'),
+        ],
+        ['id' => (int) $jobId],
+        ['%s', '%s'],
+        ['%d']
+    );
+}


### PR DESCRIPTION
## Summary
- add shared helpers for image generation tables, row normalization, and filtered queries
- refactor the image generation proxy to centralize validation, logging, and RabbitMQ publication
- modernize image status, AJAX, and REST endpoints to reuse the shared helpers and sanitize inputs
- centralize the custom table prefix so every image-generation entry point uses the WPC_ tables consistently

## Testing
- php -l includes/image_generation.php
- php -l includes/proxy/generate_image.php
- php -l includes/image_status.php
- php -l includes/get_all_images.php
- php -l includes/get_generated_images.php
- php -l includes/api/api_images.php
- php -l api/images/save.php


------
https://chatgpt.com/codex/tasks/task_e_68dc499b36f8832293c511bb63e65b47