### PR TITLE
Fix generation preview sizing on narrow screens

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -846,22 +846,21 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .generation-preview__main {
-    flex: 0 1 var(--generation-preview-max-size);
-    position: relative;
-    overflow: hidden;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.04);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 0;
-    aspect-ratio: 1 / 1;
-    width: min(100%, var(--generation-preview-max-size));
-    max-width: 100%;
-    max-height: min(100%, var(--generation-preview-max-size));
-    height: auto;
-}
+        flex: 0 1 var(--generation-preview-max-size);
+        position: relative;
+        overflow: hidden;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid rgba(255, 255, 255, 0.04);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 0;
+        aspect-ratio: 1 / 1;
+        width: min(100%, var(--generation-preview-max-size));
+        max-width: 100%;
+        height: auto;
+    }
 
 #customize-main.customize-layout:not(.hub-layout)
     > #content
@@ -985,7 +984,6 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
         > .content-images
         .generation-preview__main {
         width: min(100%, var(--generation-preview-max-size));
-        max-height: min(100%, var(--generation-preview-max-size));
         aspect-ratio: 1 / 1;
         height: auto;
     }


### PR DESCRIPTION
## Summary
- remove max-height constraints from the main generation preview container so the aspect ratio keeps it square as the viewport shrinks
- ensure the responsive rules rely on the element's width to maintain a square preview on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc6a181374832289d3c0e3cbe3718b