### PR TITLE
Fix generation preview container aspect ratio

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -855,6 +855,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
         display: flex;
         align-items: center;
         justify-content: center;
+        align-self: center;
         min-height: 0;
         aspect-ratio: 1 / 1;
         width: min(100%, var(--generation-preview-max-size));


### PR DESCRIPTION
## Summary
- prevent the generation preview's main container from stretching and breaking its square aspect ratio by centering the flex item

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc71b06f808322b517ad6cea949cab