### PR TITLE
Hide loyalty label on compact headers

### DIFF
--- a/header.php
+++ b/header.php
@@ -62,7 +62,7 @@ if ( $user_logged_in ) {
                                 <div class="account-icons-container">
 <?php if ( function_exists( 'customiizer_loyalty_widget' ) ) : ?>
                                         <div class="loyalty-header-container">
-                                                <button type="button" id="loyalty-widget-button" class="loyalty-header-button icon-button" aria-haspopup="dialog" aria-expanded="false">
+                                                <button type="button" id="loyalty-widget-button" class="loyalty-header-button icon-button" aria-haspopup="dialog" aria-expanded="false" aria-label="<?php echo esc_attr__( 'Mes avantages', 'customiizer' ); ?>">
                                                         <i class="fas fa-gift" aria-hidden="true"></i>
                                                         <span class="loyalty-header-label"><?php echo esc_html__( 'Mes avantages', 'customiizer' ); ?></span>
                                                 </button>

--- a/styles/header.css
+++ b/styles/header.css
@@ -347,6 +347,17 @@
         color: #ffffff;
 }
 
+@media (max-width: 1100px) {
+       .loyalty-header-button {
+               padding-inline: 14px;
+               gap: 0;
+       }
+
+       .loyalty-header-button .loyalty-header-label {
+               display: none;
+       }
+}
+
 .cart-container {
         position: relative;
 }


### PR DESCRIPTION
## Summary
- add an accessibility label to the loyalty widget trigger button
- hide the loyalty label text and tighten spacing when the header width is narrow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc815a2d808322af29d66caced2220