### PR TITLE
Ensure generated preview image supports enlarge overlay

### DIFF
--- a/js/generate/generate.js
+++ b/js/generate/generate.js
@@ -287,7 +287,7 @@ jQuery(function($) {
 
                 const mainImage = previewGalleryImages[selectedPreviewIndex];
                 applyImageMetaToElement(previewImage, mainImage);
-                previewImage.classList.remove('preview-enlarge');
+                previewImage.classList.add('preview-enlarge');
 
                 thumbnailsContainer.innerHTML = '';
                 previewGalleryImages.forEach((imageData, index) => {


### PR DESCRIPTION
## Summary
- ensure the main generated preview image keeps the preview-enlarge class once populated so the overlay can be used with metadata

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcce85fa1483229e06614e661beaf9