### PR TITLE
Align generation preview container layout

### DIFF
--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -822,17 +822,24 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 
 #customize-main.customize-layout:not(.hub-layout) > #content > .content-images .generation-preview {
     display: none;
-    width: 100%;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
     gap: 16px;
     flex: 1 1 auto;
     max-height: min(100%, max(280px, calc(100dvh - var(--header-height, 88px) - 120px)));
     min-height: 0;
+    padding: 0 8px;
+    box-sizing: border-box;
+    margin: 0 auto;
+    width: min(
+        100%,
+        calc(var(--generation-preview-max-size) + var(--generation-preview-thumbnails-width) + 16px)
+    );
     --generation-preview-max-size: max(
         280px,
         calc(100dvh - var(--header-height, 88px) - 120px)
     );
+    --generation-preview-thumbnails-width: 152px;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -855,7 +862,7 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
         display: flex;
         align-items: center;
         justify-content: center;
-        align-self: flex-start;
+        align-self: center;
         min-height: 0;
         aspect-ratio: 1 / 1;
         width: min(100%, var(--generation-preview-max-size));
@@ -877,15 +884,15 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .generation-preview__thumbnails {
-    width: 152px;
+    width: var(--generation-preview-thumbnails-width);
     display: flex;
     flex-direction: column;
     gap: 12px;
-    flex: 0 0 152px;
+    flex: 0 0 var(--generation-preview-thumbnails-width);
     max-height: var(--generation-preview-max-size);
-    height: 100%;
+    height: auto;
     overflow: auto;
-    align-self: stretch;
+    align-self: flex-start;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -969,8 +976,8 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     #customize-main.customize-layout:not(.hub-layout)
         > #content
         > .content-images
-        .generation-preview__thumbnails {
-        width: 132px;
+        .generation-preview {
+        --generation-preview-thumbnails-width: 132px;
     }
 }
 
@@ -991,6 +998,13 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
         width: min(100%, var(--generation-preview-max-size));
         aspect-ratio: 1 / 1;
         height: auto;
+    }
+
+    #customize-main.customize-layout:not(.hub-layout)
+        > #content
+        > .content-images
+        .generation-preview {
+        width: min(100%, var(--generation-preview-max-size));
     }
 
     #customize-main.customize-layout:not(.hub-layout)


### PR DESCRIPTION
## Summary
- center the generation preview wrapper with the same width constraints as the image grid
- adjust thumbnail column sizing to avoid stretching and keep the preview group compact
- tune responsive rules so the preview maintains the grid alignment on smaller screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dcd84ae77c8322851ac33ef2fb1bba