### PR TITLE
Add direct product usage button to generation preview

### DIFF
--- a/js/generate/show_images.js
+++ b/js/generate/show_images.js
@@ -2,14 +2,76 @@ var allImages = [];
 const PLACEHOLDER_IMAGE_SRC = 'https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png';
 
 jQuery(document).ready(function() {
-	// Requête AJAX pour récupérer les images
-	loadImages();
+        // Requête AJAX pour récupérer les images
+        loadImages();
+
+        initializeGenerationPreviewUseButton();
 });
 
+function initializeGenerationPreviewUseButton() {
+        const previewImage = document.getElementById('generation-preview-image');
+        const useButton = document.getElementById('generation-preview-use-button');
+
+        if (!previewImage || !useButton) {
+                return;
+        }
+
+        const updateButtonState = () => {
+                const canUseImage =
+                        previewImage.classList.contains('preview-enlarge') &&
+                        Boolean(previewImage.getAttribute('data-format-image'));
+
+                useButton.disabled = !canUseImage;
+                useButton.classList.toggle('is-disabled', !canUseImage);
+
+                if (!canUseImage) {
+                        useButton.setAttribute('aria-disabled', 'true');
+                } else {
+                        useButton.removeAttribute('aria-disabled');
+                }
+        };
+
+        const observer = new MutationObserver(updateButtonState);
+        observer.observe(previewImage, {
+                attributes: true,
+                attributeFilter: ['src', 'class', 'data-format-image', 'data-prompt']
+        });
+
+        updateButtonState();
+
+        useButton.addEventListener('click', () => {
+                if (useButton.disabled) {
+                        return;
+                }
+
+                const src = previewImage.getAttribute('src');
+                const format = previewImage.getAttribute('data-format-image');
+                const prompt = previewImage.getAttribute('data-prompt');
+                const displayName = previewImage.getAttribute('data-display_name') || '';
+                const userId = previewImage.getAttribute('data-user-id') || '';
+
+                if (typeof startImageProductUsageFlow === 'function') {
+                        const result = startImageProductUsageFlow({
+                                src,
+                                prompt,
+                                format
+                        });
+
+                        if (!result || result.success !== true) {
+                                if (typeof openImageOverlay === 'function') {
+                                        openImageOverlay(src, userId, displayName, format, prompt);
+                                }
+                        }
+                } else if (typeof openImageOverlay === 'function') {
+                        openImageOverlay(src, userId, displayName, format, prompt);
+                }
+        });
+}
+
 function loadImages() {
-	if (allImages.length === 0) {
-		fetch('/wp-json/api/v1/images/load')
-			.then(response => response.json())
+        if (allImages.length === 0) {
+                fetch('/wp-json/api/v1/images/load')
+                        .then(response => response.json())
 			.then(data => { // ← ICI
 
 			if (data.success && data.images) {

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -873,6 +873,78 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
 #customize-main.customize-layout:not(.hub-layout)
     > #content
     > .content-images
+    .generation-preview__use-button {
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+    appearance: none;
+    border: none;
+    border-radius: 999px;
+    background: rgba(10, 12, 15, 0.72);
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 10px 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    cursor: pointer;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+    transform: translateY(8px);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__main:hover
+    .generation-preview__use-button,
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__main:focus-within
+    .generation-preview__use-button,
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__use-button:focus-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__use-button span {
+    pointer-events: none;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__use-button:focus-visible {
+    outline: 2px solid var(--color-brand-400, #2bd879);
+    outline-offset: 2px;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
+    .generation-preview__use-button:disabled {
+    cursor: not-allowed;
+    background: rgba(10, 12, 15, 0.48);
+    box-shadow: none;
+}
+
+#customize-main.customize-layout:not(.hub-layout)
+    > #content
+    > .content-images
     .generation-preview__main
     .centered-image {
     width: 100%;

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -91,6 +91,14 @@
                                 src="https://customiizer.blob.core.windows.net/assets/SiteDesign/img/attente.png"
                                 alt="Image d'attente"
                         />
+                        <button
+                                type="button"
+                                id="generation-preview-use-button"
+                                class="generation-preview__use-button"
+                                aria-label="Utiliser cette image sur un produit"
+                        >
+                                <span>Utiliser sur un produit</span>
+                        </button>
                 </div>
                 <div id="generation-preview-thumbnails" class="generation-preview__thumbnails" aria-label="Variations générées">
                         <button type="button" class="generation-preview__thumbnail is-placeholder" disabled>


### PR DESCRIPTION
## Summary
- add a hover-revealed button on the generation preview to trigger direct product usage
- style the preview container button and manage hover/focus interactions
- centralize product usage helpers and wire the generation preview button into the existing flow

## Testing
- php -l templates/generate/main-content.php

------
https://chatgpt.com/codex/tasks/task_e_68dcdca13ca48322ba41a4be55232b99