### PR TITLE
Adjust community gallery image spacing and corners

### DIFF
--- a/styles/community.css
+++ b/styles/community.css
@@ -297,7 +297,7 @@
 .image-container {
     display: flex;
     align-items: flex-start;
-    gap: clamp(16px, 3vw, 28px);
+    gap: clamp(8px, 1.5vw, 14px);
     width: 100%;
     box-sizing: border-box;
 }
@@ -311,8 +311,8 @@
 
 .imageContainer {
     position: relative;
-    margin-bottom: clamp(18px, 3vw, 28px);
-    border-radius: 20px;
+    margin-bottom: clamp(9px, 1.5vw, 14px);
+    border-radius: 0;
     overflow: hidden;
     background: rgba(0, 0, 0, 0.45);
     box-shadow: 0 22px 44px rgba(0, 0, 0, 0.55);

--- a/styles/responsive/mobile/community.css
+++ b/styles/responsive/mobile/community.css
@@ -12,7 +12,7 @@
         }
 
         .image-container {
-                gap: 16px;
+                gap: 8px;
                 box-sizing: border-box;
         }
 }


### PR DESCRIPTION
## Summary
- remove the rounded corners from community gallery image cards
- reduce the spacing between community gallery images on desktop and mobile layouts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd499f653c8322b11741e22548decf