### PR TITLE
Add scroll-to-top control to community page

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -267,6 +267,7 @@ function customiizer_enqueue_customize_assets() {
                 wp_enqueue_style('community-style', get_stylesheet_directory_uri() . '/styles/community.css', [], $ver);
 
 		// --- JS internes ---
+		wp_enqueue_script('home-scroll-top', get_stylesheet_directory_uri() . '/js/home/scroll-to-top.js', ['jquery'], $ver, true);
                 wp_enqueue_script('community-images', get_stylesheet_directory_uri() . '/js/community/show_images.js', ['jquery'], $ver, true);
 
 		// Page /mycreation

--- a/styles/community.css
+++ b/styles/community.css
@@ -116,6 +116,7 @@
     font-weight: 700;
     letter-spacing: -0.02em;
     color: rgba(246, 246, 246, 0.96);
+    white-space: nowrap;
 }
 
 .community-hero__description {
@@ -465,6 +466,43 @@
     color: rgba(240, 240, 240, 0.85);
     text-align: center;
     font-size: 0.95rem;
+}
+
+.scroll-to-top {
+    position: fixed;
+    right: clamp(16px, 3vw, 32px);
+    bottom: clamp(18px, 4vw, 36px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border: none;
+    border-radius: 999px;
+    background: var(--community-accent-strong, #1fb86c);
+    color: #07120c;
+    cursor: pointer;
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
+    z-index: 24;
+}
+
+.scroll-to-top i {
+    font-size: 1.15rem;
+}
+
+.scroll-to-top:focus-visible {
+    outline: 2px solid rgba(43, 216, 121, 0.85);
+    outline-offset: 4px;
+}
+
+.scroll-to-top.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
 }
 
 @media (max-width: 1200px) {

--- a/styles/responsive/mobile/community.css
+++ b/styles/responsive/mobile/community.css
@@ -11,6 +11,10 @@
                 border-radius: 24px;
         }
 
+        .community-hero__title {
+                white-space: normal;
+        }
+
         .image-container {
                 gap: 16px;
                 box-sizing: border-box;
@@ -38,5 +42,10 @@
 
         .image-container {
                 flex-direction: column;
+        }
+
+        .scroll-to-top {
+                width: 44px;
+                height: 44px;
         }
 }

--- a/templates/community/main-content.php
+++ b/templates/community/main-content.php
@@ -32,6 +32,10 @@
                 <div id="load-more-trigger" aria-hidden="true"></div>
         </section>
 
+        <button class="scroll-to-top" type="button" aria-label="Revenir en haut">
+                <i class="fas fa-arrow-up" aria-hidden="true"></i>
+        </button>
+
         <div id="imageModal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">
                 <img class="modal-content" id="modalImage" alt="">
                 <div id="caption"></div>


### PR DESCRIPTION
## Summary
- add a scroll-to-top shortcut to the community template and style it with the page palette
- load the existing scroll-to-top behavior on the community route and keep the hero title on a single line on desktop while allowing wrap on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd4985d3048322a254db24387803e6