### PR TITLE
Add teardown for Three.js scene in product customizer

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -416,6 +416,10 @@ jQuery(document).ready(function ($) {
                 // Démarre le suivi du temps dès le clic sur "Valider la personnalisation"
                 window.mockupTimes.pending = Date.now();
 
+                if (typeof window.destroy3DScene === 'function') {
+                        window.destroy3DScene();
+                }
+
                 jQuery('#customizeModal').hide();
 
                 if (typeof window.showLoadingOverlay === 'function') {
@@ -975,6 +979,11 @@ jQuery(document).ready(function ($) {
                        }
                        CanvasManager.init(template, 'product2DContainer');
                        updateAddImageButtonVisibility();
+                       if (typeof window.destroy3DScene === 'function') {
+                               window.destroy3DScene();
+                       }
+                       threeDInitialized = false;
+
                        if (variant.url_3d) {
                                $('#product3DContainer').show();
                                init3DScene('product3DContainer', variant.url_3d, 'threeDCanvas');
@@ -1082,6 +1091,11 @@ jQuery(document).ready(function ($) {
                         // La personnalisation est restaurée automatiquement lors d'une ouverture manuelle.
 
                         // 3. Lancer Three.js si disponible
+                        if (typeof window.destroy3DScene === 'function') {
+                                window.destroy3DScene();
+                        }
+                        threeDInitialized = false;
+
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
@@ -1103,6 +1117,10 @@ jQuery(document).ready(function ($) {
                 } catch (err) {
                         console.warn('[Autosave] flush modal-close failed', err);
                 }
+                if (typeof window.destroy3DScene === 'function') {
+                        window.destroy3DScene();
+                }
+                threeDInitialized = false;
                 customizeModal.hide();
                 releaseFocus(customizeModal);
                 updateAddImageButtonVisibility();

--- a/js/product/threeDManager.js
+++ b/js/product/threeDManager.js
@@ -7,6 +7,7 @@
 let scene, camera, renderer, controls;
 let resizeObserver3D = null;
 let modelRoot = null;
+let animationFrameId = null;
 
 // zones[zoneName] = { fill: Mesh, overlay: Mesh }
 let zones = {};
@@ -40,6 +41,7 @@ function fitCameraToObject(camera, object, controls, renderer, offset=2){
 
 // —————————————— Helpers zones ——————————————
 function getZone(zoneName=null){
+  if(!zones) return null;
   if(zoneName && zones[zoneName]) return zones[zoneName];
   // sinon, prend la première zone dont le nom contient "impression"
   const key = Object.keys(zones).find(n => n.toLowerCase().includes('impression'));
@@ -48,6 +50,8 @@ function getZone(zoneName=null){
 
 // —————————————— INIT (HDR par défaut + fallback) ——————————————
 function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
+  destroy3DScene();
+
   const container = document.getElementById(containerId);
   const canvas    = document.getElementById(canvasId);
   if(!container || !canvas){
@@ -56,6 +60,7 @@ function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
   }
 
   scene = new THREE.Scene();
+  zones = {};
 
   const rect = container.getBoundingClientRect();
   const width  = Math.max(1, rect.width);
@@ -217,7 +222,8 @@ window.update3DTextureFromCanvas = async function(canvas, zoneName=null){
     const tex = await texLoader.loadAsync(url);
     tex.flipY = false;
     if('colorSpace' in tex) tex.colorSpace = THREE.SRGBColorSpace; else tex.encoding = THREE.sRGBEncoding;
-    tex.anisotropy = renderer.capabilities.getMaxAnisotropy?.() || 1;
+    const maxAnisotropy = renderer?.capabilities?.getMaxAnisotropy?.();
+    tex.anisotropy = (typeof maxAnisotropy === 'number' && maxAnisotropy > 0) ? maxAnisotropy : 1;
     tex.needsUpdate = true;
 
     const m = zone.overlay.material.clone();
@@ -254,6 +260,10 @@ window.clear3DTexture = function(zoneName=null){
 // —————————————— Debug ——————————————
 window.logZones = function(){
   const out = {};
+  if(!zones){
+    console.table(out);
+    return;
+  }
   for(const k of Object.keys(zones)){
     out[k] = { fill: !!zones[k].fill, overlay: !!zones[k].overlay };
   }
@@ -262,10 +272,72 @@ window.logZones = function(){
 
 // —————————————— Loop ——————————————
 function animate(){
-  requestAnimationFrame(animate);
+  animationFrameId = requestAnimationFrame(animate);
   if(controls) controls.update();
   if(renderer && scene && camera) renderer.render(scene, camera);
 }
 
+function disposeMaterial(material){
+  if(!material) return;
+  if(Array.isArray(material)){
+    material.forEach(disposeMaterial);
+    return;
+  }
+  const textureProps = [
+    'map','lightMap','aoMap','emissiveMap','bumpMap','normalMap','displacementMap',
+    'roughnessMap','metalnessMap','alphaMap','envMap','specularMap','gradientMap'
+  ];
+  for(const prop of textureProps){
+    const tex = material[prop];
+    if(tex && typeof tex.dispose === 'function'){
+      tex.dispose();
+    }
+  }
+  if(typeof material.dispose === 'function') material.dispose();
+}
+
+function destroy3DScene(){
+  if(animationFrameId !== null){
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+
+  if(controls && typeof controls.dispose === 'function') controls.dispose();
+  controls = null;
+
+  if(resizeObserver3D){
+    resizeObserver3D.disconnect();
+    resizeObserver3D = null;
+  }
+
+  if(scene){
+    scene.traverse((child)=>{
+      if(child.isMesh){
+        if(child.geometry && typeof child.geometry.dispose === 'function') child.geometry.dispose();
+        disposeMaterial(child.material);
+      } else if(child.material){
+        disposeMaterial(child.material);
+      }
+    });
+
+    if(scene.environment && typeof scene.environment.dispose === 'function') scene.environment.dispose();
+    if(scene.background && typeof scene.background.dispose === 'function') scene.background.dispose();
+  }
+
+  if(modelRoot && scene) scene.remove(modelRoot);
+
+  if(renderer){
+    if(typeof renderer.dispose === 'function') renderer.dispose();
+    if(typeof renderer.forceContextLoss === 'function') renderer.forceContextLoss();
+  }
+
+  scene = null;
+  camera = null;
+  renderer = null;
+  modelRoot = null;
+  zones = null;
+}
+
 // —————————————— API ——————————————
 window.init3DScene = init3DScene;
+window.destroy3DScene = destroy3DScene;


### PR DESCRIPTION
## Summary
- add a destroy3DScene helper that cancels the render loop and disposes Three.js resources
- invoke destroy3DScene whenever the modal closes or a new variant initializes to avoid leaks
- harden texture loading against a missing renderer during cleanup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4e9cc49c8322a224fd087e109a10