### PR TITLE
Ensure 3D viewer HDR reloads when reopening customizer

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -417,6 +417,9 @@ jQuery(document).ready(function ($) {
                 window.mockupTimes.pending = Date.now();
 
                 jQuery('#customizeModal').hide();
+                if (typeof window.reset3DScene === 'function') {
+                        window.reset3DScene();
+                }
 
                 if (typeof window.showLoadingOverlay === 'function') {
                         window.showLoadingOverlay();
@@ -977,6 +980,9 @@ jQuery(document).ready(function ($) {
                        updateAddImageButtonVisibility();
                        if (variant.url_3d) {
                                $('#product3DContainer').show();
+                               if (typeof window.reset3DScene === 'function') {
+                                       window.reset3DScene();
+                               }
                                init3DScene('product3DContainer', variant.url_3d, 'threeDCanvas');
                                threeDInitialized = true;
                        } else {
@@ -1084,6 +1090,9 @@ jQuery(document).ready(function ($) {
                         // 3. Lancer Three.js si disponible
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
+                                if (typeof window.reset3DScene === 'function') {
+                                        window.reset3DScene();
+                                }
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
                                 threeDInitialized = true;
                         } else {
@@ -1106,6 +1115,9 @@ jQuery(document).ready(function ($) {
                 customizeModal.hide();
                 releaseFocus(customizeModal);
                 updateAddImageButtonVisibility();
+                if (typeof window.reset3DScene === 'function') {
+                        window.reset3DScene();
+                }
         });
 
         // Afficher le bouton lors du changement de produit

--- a/js/product/product_details.js
+++ b/js/product/product_details.js
@@ -1004,7 +1004,10 @@ jQuery(document).ready(function ($) {
                                         container.show();
                                         if (!main3DInitialized) {
                                                 requestAnimationFrame(() => {
-                                                        init3DScene('productMain3DContainer', variant.url_3d, variant.color, 'productMain3DCanvas');
+                                                        if (typeof window.reset3DScene === 'function') {
+                                                                window.reset3DScene();
+                                                        }
+                                                        init3DScene('productMain3DContainer', variant.url_3d, 'productMain3DCanvas');
                                                 });
                                                 main3DInitialized = true;
                                         }

--- a/js/product/threeDManager.js
+++ b/js/product/threeDManager.js
@@ -7,6 +7,7 @@
 let scene, camera, renderer, controls;
 let resizeObserver3D = null;
 let modelRoot = null;
+let animationFrameId = null;
 
 // zones[zoneName] = { fill: Mesh, overlay: Mesh }
 let zones = {};
@@ -47,6 +48,33 @@ function getZone(zoneName=null){
 }
 
 // —————————————— INIT (HDR par défaut + fallback) ——————————————
+function reset3DScene(){
+  if(animationFrameId !== null){
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+
+  if(resizeObserver3D){
+    resizeObserver3D.disconnect();
+    resizeObserver3D = null;
+  }
+
+  if(controls && typeof controls.dispose === 'function'){
+    controls.dispose();
+  }
+  controls = null;
+
+  if(renderer && typeof renderer.dispose === 'function'){
+    renderer.dispose();
+  }
+  renderer = null;
+
+  scene = null;
+  camera = null;
+  modelRoot = null;
+  zones = {};
+}
+
 function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
   const container = document.getElementById(containerId);
   const canvas    = document.getElementById(canvasId);
@@ -262,10 +290,11 @@ window.logZones = function(){
 
 // —————————————— Loop ——————————————
 function animate(){
-  requestAnimationFrame(animate);
+  animationFrameId = requestAnimationFrame(animate);
   if(controls) controls.update();
   if(renderer && scene && camera) renderer.render(scene, camera);
 }
 
 // —————————————— API ——————————————
 window.init3DScene = init3DScene;
+window.reset3DScene = reset3DScene;


### PR DESCRIPTION
## Summary
- add a reusable `reset3DScene` helper to dispose the current Three.js scene and animation loop
- call the reset when closing the customizer or loading a new variant so the HDR environment is reloaded
- update the product page 3D entry point to reset before initializing and use the correct canvas id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd54771da483228714083bbc418960