### PR TITLE
Fix Three.js renderer sizing when modal opens

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -1037,6 +1037,7 @@ jQuery(document).ready(function ($) {
                 threeDInitialized = false;
                 fetchUserImages(); // images perso si besoin
                 customizeModal.show();
+                setTimeout(() => window.force3DResize?.(), 50);
                 const productImageSrc = jQuery("#product-main-image").attr("src");
                 jQuery("#footerProductImage").attr("src", productImageSrc);
                 const productName = jQuery(".product-name").text().trim();
@@ -1085,6 +1086,7 @@ jQuery(document).ready(function ($) {
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
+                                window.force3DResize?.();
                                 threeDInitialized = true;
                         } else {
                                 $('#product3DContainer').hide();

--- a/js/product/threeDManager.js
+++ b/js/product/threeDManager.js
@@ -7,6 +7,7 @@
 let scene, camera, renderer, controls;
 let resizeObserver3D = null;
 let modelRoot = null;
+let containerEl = null;
 
 // zones[zoneName] = { fill: Mesh, overlay: Mesh }
 let zones = {};
@@ -47,6 +48,19 @@ function getZone(zoneName=null){
 }
 
 // —————————————— INIT (HDR par défaut + fallback) ——————————————
+function forceRendererResize(){
+  if(!renderer || !camera || !containerEl) return;
+  const rect = containerEl.getBoundingClientRect();
+  const width  = Math.max(1, rect.width);
+  const height = Math.max(1, rect.height || rect.width);
+  renderer.setSize(width, height, false);
+  camera.aspect = width/height;
+  camera.updateProjectionMatrix();
+  renderOnce();
+}
+
+window.force3DResize = () => requestAnimationFrame(forceRendererResize);
+
 function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
   const container = document.getElementById(containerId);
   const canvas    = document.getElementById(canvasId);
@@ -54,6 +68,8 @@ function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
     setTimeout(()=>init3DScene(containerId, modelUrl, canvasId, opts), 120);
     return;
   }
+
+  containerEl = container;
 
   scene = new THREE.Scene();
 
@@ -114,6 +130,8 @@ function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
     camera.aspect = w/h; camera.updateProjectionMatrix(); renderOnce();
   });
   resizeObserver3D.observe(container);
+
+  forceRendererResize();
 
   loadModel(modelUrl);
   animate();


### PR DESCRIPTION
## Summary
- ensure the Three.js manager keeps track of its container and exposes a resize helper for modal openings
- trigger the resize helper after the customization modal is shown and after initializing the 3D scene

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd708a3a38832280501ab722b3f667