### PR TITLE
Improve Three.js modal resize reliability

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -1037,6 +1037,7 @@ jQuery(document).ready(function ($) {
                 threeDInitialized = false;
                 fetchUserImages(); // images perso si besoin
                 customizeModal.show();
+                setTimeout(() => window.force3DResize?.(), 50);
                 const productImageSrc = jQuery("#product-main-image").attr("src");
                 jQuery("#footerProductImage").attr("src", productImageSrc);
                 const productName = jQuery(".product-name").text().trim();
@@ -1085,6 +1086,7 @@ jQuery(document).ready(function ($) {
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
+                                window.force3DResize?.();
                                 threeDInitialized = true;
                         } else {
                                 $('#product3DContainer').hide();


### PR DESCRIPTION
## Summary
- ensure the Three.js manager keeps track of its container and exposes a resize helper for modal openings
- trigger the resize helper after the customization modal is shown and after initializing the 3D scene
- retry the renderer resize until the modal container has real dimensions and ignore zero-sized observer updates so reopening the modal no longer renders black

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd708a3a38832280501ab722b3f667