### PR TITLE
Ensure 3D scene resets when reopening customizer

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -983,6 +983,9 @@ jQuery(document).ready(function ($) {
             $('#product3DContainer').show();
 
             if (!threeDInitialized) {
+                if (typeof window.dispose3DScene === 'function') {
+                    window.dispose3DScene();
+                }
                 // Première fois → init complet
                 init3DScene('product3DContainer', variant.url_3d, 'threeDCanvas');
                 threeDInitialized = true;
@@ -1048,6 +1051,9 @@ jQuery(document).ready(function ($) {
 
         // 2) Ouvrir le modal de personnalisation
         customizeButton.on('click', async function (event) {
+                if (typeof window.dispose3DScene === 'function') {
+                        window.dispose3DScene();
+                }
                 threeDInitialized = false;
                 fetchUserImages(); // images perso si besoin
                 customizeModal.show();
@@ -1098,6 +1104,9 @@ jQuery(document).ready(function ($) {
                         // 3. Lancer Three.js si disponible
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
+                                if (typeof window.dispose3DScene === 'function') {
+                                        window.dispose3DScene();
+                                }
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
                                 threeDInitialized = true;
                         } else {
@@ -1119,6 +1128,10 @@ jQuery(document).ready(function ($) {
                 }
                 customizeModal.hide();
                 releaseFocus(customizeModal);
+                if (typeof window.dispose3DScene === 'function') {
+                        window.dispose3DScene();
+                }
+                threeDInitialized = false;
                 updateAddImageButtonVisibility();
         });
 

--- a/js/product/threeDManager.js
+++ b/js/product/threeDManager.js
@@ -11,6 +11,32 @@ let modelRoot = null;
 // zones[zoneName] = { fill: Mesh, overlay: Mesh }
 let zones = {};
 
+function disposeMaterial(mat) {
+  if (!mat) return;
+
+  const textureKeys = [
+    'map',
+    'normalMap',
+    'roughnessMap',
+    'metalnessMap',
+    'aoMap',
+    'alphaMap',
+    'emissiveMap'
+  ];
+
+  textureKeys.forEach((key) => {
+    const tex = mat[key];
+    if (tex && typeof tex.dispose === 'function') {
+      mat[key] = null;
+      tex.dispose();
+    }
+  });
+
+  if (typeof mat.dispose === 'function') {
+    mat.dispose();
+  }
+}
+
 // —————————————— Échelle produit ——————————————
 const productScales = { mug:[1.2,1.2,1.2], tumbler:[1.5,1.5,1.5], bottle:[2,2,2] };
 function getScaleForProduct(modelUrl){
@@ -280,6 +306,57 @@ window.refresh3DModal = function(containerId = 'product3DContainer') {
   } else {
     renderOnce();
   }
+};
+
+window.dispose3DScene = function() {
+  if (resizeObserver3D) {
+    resizeObserver3D.disconnect();
+    resizeObserver3D = null;
+  }
+
+  if (controls && typeof controls.dispose === 'function') {
+    controls.dispose();
+  }
+  controls = null;
+
+  if (scene) {
+    const env = scene.environment;
+    if (env && typeof env.dispose === 'function') {
+      env.dispose();
+    }
+
+    scene.traverse((child) => {
+      if (child.isMesh) {
+        if (child.geometry && typeof child.geometry.dispose === 'function') {
+          child.geometry.dispose();
+        }
+
+        if (Array.isArray(child.material)) {
+          child.material.forEach(disposeMaterial);
+        } else {
+          disposeMaterial(child.material);
+        }
+      }
+    });
+  }
+
+  scene = null;
+  camera = null;
+  modelRoot = null;
+  zones = {};
+
+  if (renderer) {
+    renderer.dispose();
+    if (typeof renderer.forceContextLoss === 'function') {
+      renderer.forceContextLoss();
+    }
+    if (renderer.domElement) {
+      renderer.domElement.width = 0;
+      renderer.domElement.height = 0;
+    }
+  }
+
+  renderer = null;
 };
 
 // —————————————— Debug ——————————————


### PR DESCRIPTION
## Summary
- dispose the Three.js scene, renderer, and observers when the customizer modal closes
- reset and reinitialize the 3D scene whenever the customizer modal opens to reload HDR lighting reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd765eefd0832296c5c2c0fc8f2b99