### PR TITLE
Fix 3D scene disposal for modal reopen

### DIFF
--- a/js/product/product_customize.js
+++ b/js/product/product_customize.js
@@ -983,6 +983,9 @@ jQuery(document).ready(function ($) {
             $('#product3DContainer').show();
 
             if (!threeDInitialized) {
+                if (typeof window.dispose3DScene === 'function') {
+                    window.dispose3DScene();
+                }
                 // Première fois → init complet
                 init3DScene('product3DContainer', variant.url_3d, 'threeDCanvas');
                 threeDInitialized = true;
@@ -1048,6 +1051,9 @@ jQuery(document).ready(function ($) {
 
         // 2) Ouvrir le modal de personnalisation
         customizeButton.on('click', async function (event) {
+                if (typeof window.dispose3DScene === 'function') {
+                        window.dispose3DScene();
+                }
                 threeDInitialized = false;
                 fetchUserImages(); // images perso si besoin
                 customizeModal.show();
@@ -1098,6 +1104,9 @@ jQuery(document).ready(function ($) {
                         // 3. Lancer Three.js si disponible
                         if (selectedVariant.url_3d) {
                                 $('#product3DContainer').show();
+                                if (typeof window.dispose3DScene === 'function') {
+                                        window.dispose3DScene();
+                                }
                                 init3DScene('product3DContainer', selectedVariant.url_3d, 'threeDCanvas');
                                 threeDInitialized = true;
                         } else {
@@ -1119,6 +1128,10 @@ jQuery(document).ready(function ($) {
                 }
                 customizeModal.hide();
                 releaseFocus(customizeModal);
+                if (typeof window.dispose3DScene === 'function') {
+                        window.dispose3DScene();
+                }
+                threeDInitialized = false;
                 updateAddImageButtonVisibility();
         });
 


### PR DESCRIPTION
## Summary
- stop forcing WebGL context loss when disposing the Three.js renderer so the canvas can acquire a new context on reopen
- cancel the pending animation frame loop and clear the stored environment reference during disposal to ensure a clean reset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd765eefd0832296c5c2c0fc8f2b99