### PR TITLE
Delay 3D model display until HDR loads

### DIFF
--- a/styles/design_product.css
+++ b/styles/design_product.css
@@ -879,10 +879,18 @@
 
 /* Loader 3D */
 #product3DContainer .loading-overlay {
-  position: absolute; inset: 0;
+  position: absolute;
+  inset: 0;
   background: rgba(0,0,0,.5);
-  display: flex; align-items: center; justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  text-align: center;
+  color: #ffffff;
   z-index: 5;
+  transition: opacity 0.25s ease;
 }
 #product3DContainer .loading-spinner {
   width: 50px; height: 50px;
@@ -890,6 +898,11 @@
   border-top: 5px solid #fff;
   border-radius: 50%;
   animation: spin 1s linear infinite;
+}
+#product3DContainer .loading-text {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  opacity: 0.85;
 }
 @keyframes spin { 0%{transform:rotate(0)} 100%{transform:rotate(360deg)} }
 


### PR DESCRIPTION
## Summary
- add a reusable loading overlay helper for the customizer 3D scene
- wait for the HDR environment to finish loading before attaching the GLB to avoid the black model flash
- update the 3D loader overlay styling to include stacked spinner + message

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dddb7f74dc8322a15ec889ac026b51