### PR TITLE
Fix incorrect canvas creation when loading 3D product view

### DIFF
--- a/js/product/product_details.js
+++ b/js/product/product_details.js
@@ -1080,7 +1080,7 @@ jQuery(document).ready(function ($) {
                                         if (!main3DInitialized) {
                                                 requestAnimationFrame(() => {
                                                         refreshMain3DContainerLayout();
-                                                        init3DScene('productMain3DContainer', variant.url_3d, variant.color, 'productMain3DCanvas');
+                                                        init3DScene('productMain3DContainer', variant.url_3d, 'productMain3DCanvas');
                                                 });
                                                 main3DInitialized = true;
                                         } else {


### PR DESCRIPTION
## Summary
- ensure the 3D viewer initializes using the existing product canvas instead of creating a second one

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2ad053b88322b74dcf917ac3e8e4