### PR TITLE
Ensure product 3D view reinitializes after customization

### DIFF
--- a/js/product/product_details.js
+++ b/js/product/product_details.js
@@ -449,6 +449,23 @@ jQuery(document).ready(function ($) {
         let main3DInitialized = false;
         let mainImageLayoutRaf = null;
 
+        window.addEventListener('threeDSceneDisposed', function () {
+                main3DInitialized = false;
+
+                if (!selectedVariant || !selectedVariant.url_3d) {
+                        return;
+                }
+
+                if (!main3DContainer.is(':visible')) {
+                        return;
+                }
+
+                scheduleMain3DContainerLayout();
+                requestAnimationFrame(() => {
+                        init3DScene('productMain3DContainer', selectedVariant.url_3d, 'productMain3DCanvas');
+                });
+        });
+
         function computeMainImageMetrics() {
                 const imgEl = mainProductImage.get(0);
                 const containerEl = main3DContainer.get(0);
@@ -1146,6 +1163,17 @@ jQuery(document).ready(function ($) {
                                 designUrl = cached.canvas_image_url;
                         } else if (cached?.design_image_url) {
                                 designUrl = cached.design_image_url;
+                        }
+                }
+
+                if (variant?.url_3d && typeof window.is3DSceneReady === 'function' && !window.is3DSceneReady()) {
+                        main3DInitialized = false;
+
+                        if (main3DContainer.is(':visible')) {
+                                scheduleMain3DContainerLayout();
+                                requestAnimationFrame(() => {
+                                        init3DScene('productMain3DContainer', variant.url_3d, 'productMain3DCanvas');
+                                });
                         }
                 }
                 if (designUrl && typeof window.update3DTextureFromImageURL === 'function') {


### PR DESCRIPTION
## Summary
- reinitialize the main product 3D scene when the shared renderer is disposed and the container is visible
- add readiness tracking and queued texture updates so generated designs are applied once the 3D model is loaded
- expose helpers and an image URL updater to keep the main product viewer in sync with customizer output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de2c87e46c8322823ab42c9b1c037f