### PR TITLE
Reset product page 3D viewer on thumbnail click

### DIFF
--- a/js/product/product_details.js
+++ b/js/product/product_details.js
@@ -1091,6 +1091,28 @@ jQuery(document).ready(function ($) {
                                 .on('click', function () {
                                         $('.image-thumbnails .thumbnail').removeClass('selected');
                                         $(this).addClass('selected');
+
+                                        if (typeof window !== 'undefined') {
+                                                const disposeScene = typeof window.dispose3DScene === 'function'
+                                                        ? window.dispose3DScene
+                                                        : null;
+                                                const getActiveContainerId = typeof window.getActive3DContainerId === 'function'
+                                                        ? window.getActive3DContainerId
+                                                        : null;
+
+                                                if (disposeScene) {
+                                                        const activeContainerId = getActiveContainerId ? getActiveContainerId() : null;
+                                                        if (!activeContainerId || activeContainerId === 'productMain3DContainer') {
+                                                                try {
+                                                                        disposeScene();
+                                                                } catch (err) {
+                                                                        console.warn('[3D] Failed to dispose scene before main reinit', err);
+                                                                }
+                                                        }
+                                                }
+                                        }
+
+                                        main3DInitialized = false;
                                         scheduleMain3DContainerLayout();
                                         hideMainProductImage();
                                         main3DContainer.show();


### PR DESCRIPTION
## Summary
- dispose the active Three.js scene when the product page 3D thumbnail is clicked
- force a fresh initialization of the main product 3D canvas for a clean reset

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de2e5e85ec8322adf9f6a795895437