### PR TITLE
Refine mockup logging for print zone workflow

### DIFF
--- a/js/generate/generate.js
+++ b/js/generate/generate.js
@@ -4,7 +4,6 @@ if (typeof baseUrl === 'undefined') {
 
 const LOG_PREFIX = '[Customiizer][Generate]';
 const GENERATE_SAVED_VARIANT_STORAGE_KEY = 'customiizerSavedVariant';
-console.log(`${LOG_PREFIX} Script initialisé`, { baseUrl });
 
 const POLL_INTERVAL_MS = 1000;
 const UPSCALE_TARGET_COUNT = 4;
@@ -694,7 +693,6 @@ jQuery(function($) {
         }
 
         function resetGenerationState() {
-                console.log(`${LOG_PREFIX} Réinitialisation de l'état de génération`);
                 stopPolling();
 
                 currentTaskId = null;
@@ -935,15 +933,6 @@ jQuery(function($) {
                 const remoteStatus = normalizeJobStatus(job.status);
                 const upscaleDone = extractUpscaleDone(job);
                 const hasCompleted = hasCompletedUpscales(remoteStatus, upscaleDone);
-                console.log(`${LOG_PREFIX} Statut pollé`, {
-                        taskId: currentTaskId,
-                        jobId: currentJobId,
-                        rawStatus: job.status,
-                        remoteStatus,
-                        progress: progressValue,
-                        upscaleDone,
-                        hasCompleted,
-                });
                 const isErrorStatus = remoteStatus === 'error';
                 const progressForPersist = lastKnownProgress === null ? 0 : lastKnownProgress;
                 const progressForMessage = progressValue !== null ? progressValue : progressForPersist;
@@ -991,12 +980,6 @@ jQuery(function($) {
                 if (hasCompleted) {
                         const rawImages = Array.isArray(job.images) ? job.images : [];
                         const images = hasValidRenderableImage(rawImages) ? rawImages : buildFallbackImages(job);
-                        console.log(`${LOG_PREFIX} Tentative de rendu des images finalisées`, {
-                                taskId: currentTaskId,
-                                jobId: currentJobId,
-                                imagesCount: images.length,
-                                upscaleDone,
-                        });
                         const didRenderImages = renderGeneratedImages(images);
 
                         if (!didRenderImages) {
@@ -1005,20 +988,10 @@ jQuery(function($) {
                                 return;
                         }
 
-                        console.log(`${LOG_PREFIX} Rendu final confirmé, finalisation UI.`, {
-                                taskId: currentTaskId,
-                                jobId: currentJobId,
-                        });
                         finalizeGeneration(false);
                         return;
                 }
 
-                console.log(`${LOG_PREFIX} Job non finalisé, nouvelle vérification programmée.`, {
-                        taskId: currentTaskId,
-                        jobId: currentJobId,
-                        remoteStatus,
-                        upscaleDone,
-                });
                 scheduleNextPoll();
         }
 
@@ -1100,7 +1073,6 @@ jQuery(function($) {
                 togglePreviewMode(true);
                 closeProgressModal();
 
-                console.log(`${LOG_PREFIX} Images rendues`, { images });
                 return true;
         }
 
@@ -1189,18 +1161,6 @@ jQuery(function($) {
 
                 const activeVariant = getActiveVariant();
 
-                console.log(`${LOG_PREFIX} Demande de génération`, {
-                        prompt,
-                        format_image: jobFormat,
-                        userId: currentUser && currentUser.ID,
-                        variantId:
-                                activeVariant && activeVariant.variant_id != null
-                                        ? activeVariant.variant_id
-                                        : activeVariant && activeVariant.variantId != null
-                                                ? activeVariant.variantId
-                                                : null,
-                });
-
                 if (!prompt) {
                         showAlert('Veuillez entrer du texte avant de générer des images.');
                         return;
@@ -1280,7 +1240,6 @@ jQuery(function($) {
                         }
 
                         const data = await response.json();
-                        console.log(`${LOG_PREFIX} Réponse du backend`, data);
 
                         if (!data.success || !data.taskId) {
                                 throw new Error(data.message || 'Réponse invalide du backend');

--- a/js/preload_products.js
+++ b/js/preload_products.js
@@ -114,11 +114,6 @@ document.addEventListener('DOMContentLoaded', () => {
             };
 
             const added = Object.keys(map).length;
-            console.log('[preload] ratios produits mémorisés', {
-                contexte: context,
-                formatsAjoutes: added,
-                totalFormats: Object.keys(window.customizerCache.formatProducts).length
-            });
 
             return added;
         } catch (error) {

--- a/js/preview_image.js
+++ b/js/preview_image.js
@@ -159,11 +159,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const missing = ratios.filter((format) => typeof cache.get(format) === 'undefined');
 
     if (missing.length === 0) {
-        console.log('[preview] tous les ratios DB sont déjà en cache', { formats: ratios.length });
         return;
     }
 
-    console.log('[preview] préchargement des ratios manquants', { formats: missing.length });
     cache.preloadFormats(missing);
 });
 
@@ -241,13 +239,6 @@ function openImageOverlay(src, userId, username, formatImage, prompt) {
         const initialCachedEntry = cacheInstance && targetFormat ? cacheInstance.get(targetFormat) : undefined;
         const hasInitialCache = typeof initialCachedEntry !== 'undefined';
         const isDbRatio = targetFormat ? dbRatios.has(targetFormat) : false;
-
-        console.log('[preview] ouverture overlay', {
-                format: targetFormat || null,
-                userId,
-                knownInDb: isDbRatio,
-                hasCachedEntry: hasInitialCache
-        });
 
         const overlay = document.createElement('div');
         overlay.classList.add('preview-overlay');
@@ -413,11 +404,6 @@ function openImageOverlay(src, userId, username, formatImage, prompt) {
         };
 
         const processData = (data) => {
-                console.log('[preview] processing cached product data', {
-                        format: targetFormat || null,
-                        success: data ? data.success : undefined,
-                        choices: data && Array.isArray(data.choices) ? data.choices.length : undefined
-                });
                 if (!data || !data.success || !Array.isArray(data.choices) || data.choices.length === 0) {
                         setUndefinedFormatMessage();
                         updateUseImageButtonHandler(null);
@@ -450,13 +436,6 @@ function openImageOverlay(src, userId, username, formatImage, prompt) {
 
                         product.variants = (Array.isArray(product.variants) ? product.variants : []).filter(Boolean);
                         return product.variants.length > 0;
-                });
-
-                console.log('[preview] affichage formats via cache', {
-                        format: targetFormat || null,
-                        products: productIds.length,
-                        variants: data.choices.length,
-                        productNames: productIds.map((id) => grouped[id].name)
                 });
 
                 if (productIds.length === 0) {

--- a/js/utils/format_products_cache.js
+++ b/js/utils/format_products_cache.js
@@ -35,30 +35,12 @@
         return (value || '').toString().trim();
     }
 
-    function logCacheSnapshot(context) {
-        try {
-            const snapshot = JSON.parse(JSON.stringify(cache));
-            console.log('[preview] cache ratios enregistré', {
-                contexte: context,
-                totalFormats: Object.keys(snapshot).length,
-                contenu: snapshot
-            });
-        } catch (error) {
-            console.warn('[preview] impossible de journaliser le cache ratios', {
-                contexte: context,
-                erreur: error
-            });
-        }
-    }
-
     function persist(context = 'persist') {
         try {
             if (global.sessionStorage) {
                 global.sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache));
             }
         } catch (error) {}
-
-        logCacheSnapshot(context);
     }
 
     async function fetchFormat(format) {
@@ -219,12 +201,6 @@
             });
 
             persist(`hydrate:${context}`);
-
-            console.log('[preview] cache formats hydraté depuis variantes', {
-                contexte: context,
-                formats,
-                variantes: variants
-            });
 
             return { hydrated: true, formats, variants };
         } catch (error) {


### PR DESCRIPTION
## Summary
- strip non-essential console logging from preview, preload, and generation scripts
- add focused logs that report print zone detection and texture application in the 3D manager
- reduce /render endpoint logging to a single payload log describing the applied print area

## Testing
- php -l includes/generate_mockup.php

------
https://chatgpt.com/codex/tasks/task_e_68de96a47ce48322b130f781801a6fc0