### PR TITLE
Update default HDR lighting for 3D viewer

### DIFF
--- a/js/product/threeDManager.js
+++ b/js/product/threeDManager.js
@@ -213,7 +213,7 @@ function init3DScene(containerId, modelUrl, canvasId='threeDCanvas', opts={}){
   activeCanvasId = canvasId;
 
   // HDRI par défaut (comme ton viewer)
-  const defaultHdr = 'https://customiizer.blob.core.windows.net/assets/Hdr/studio_country_hall_1k.hdr';
+  const defaultHdr = 'https://customiizer.blob.core.windows.net/assets/Hdr/rogland_clear_night_1k.hdr';
   const useHdr = opts.hdr !== 0 && opts.hdr !== false;
   const hdrUrl = (typeof opts.hdr==='string' && opts.hdr && opts.hdr!=='1') ? opts.hdr : defaultHdr;
   const hdrIntensity = Number.isFinite(opts.hdrIntensity) ? opts.hdrIntensity : 1.0;


### PR DESCRIPTION
## Summary
- update the default HDR environment map used by the 3D viewer to rogland_clear_night_1k

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea5bfb0348322972081dc9be3927c