### PR TITLE
Fix community page layout sizing

### DIFF
--- a/styles/community.css
+++ b/styles/community.css
@@ -12,6 +12,23 @@
     display: block;
 }
 
+#customize-main:not(.customize-layout):not(.hub-layout) {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: calc(100dvh - var(--header-height, 88px));
+}
+
+#customize-main:not(.customize-layout):not(.hub-layout) > #content {
+    flex: 1 1 auto;
+    display: flex;
+    width: 100%;
+}
+
+#customize-main:not(.customize-layout):not(.hub-layout) > #content > .community-page {
+    flex: 1 1 auto;
+}
+
 .community-page {
     --community-accent: var(--color-brand-400, #2bd879);
     --community-accent-strong: var(--color-brand-500, #1fb86c);
@@ -28,7 +45,8 @@
     display: flex;
     flex-direction: column;
     gap: clamp(24px, 4vw, 40px);
-    height: 100%;
+    width: 100%;
+    min-height: calc(100dvh - var(--header-height, 88px));
     padding: clamp(24px, 4vw, 48px);
     box-sizing: border-box;
     background:
@@ -116,7 +134,6 @@
     font-weight: 700;
     letter-spacing: -0.02em;
     color: rgba(246, 246, 246, 0.96);
-    white-space: nowrap;
 }
 
 .community-hero__description {


### PR DESCRIPTION
## Summary
- ensure the community layout container expands to the available viewport height and width when the hub/customize layouts are absent
- allow the community hero title to wrap so text no longer forces the page to grow horizontally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e104f4da58832283bf0e8f22bd51ff