### PR TITLE
Adjust variant selection layout and copy

### DIFF
--- a/js/generate/show_ratio.js
+++ b/js/generate/show_ratio.js
@@ -504,11 +504,6 @@ function buildVariantSection(variants, options = {}) {
     section.className = 'product-group';
     section.setAttribute('role', 'listitem');
 
-    const title = document.createElement('h4');
-    title.className = 'product-group-title';
-    title.textContent = 'Variantes disponibles';
-    section.appendChild(title);
-
     const list = document.createElement('div');
     list.className = 'product-variants-grid';
     section.appendChild(list);

--- a/styles/customiize.css
+++ b/styles/customiize.css
@@ -214,22 +214,14 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > #content
     > .content-images
     .variant-display
-    .product-group-title {
-    margin: 0;
-    font-size: 0.95rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: rgba(239, 248, 246, 0.74);
-}
-
-#customize-main.customize-layout:not(.hub-layout)
-    > #content
-    > .content-images
-    .variant-display
     .product-variants-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(
+        auto-fit,
+        minmax(180px, min(220px, 100%))
+    );
     gap: 24px;
+    justify-content: center;
 }
 
 #customize-main.customize-layout:not(.hub-layout)
@@ -237,6 +229,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     > .content-images
     .variant-display
     .product-item {
+    max-width: 220px;
+    width: 100%;
+    justify-self: center;
     display: flex;
     flex-direction: column;
     gap: 14px;
@@ -1341,9 +1336,9 @@ body.customize-layout-page:not(.hub-layout-page) #site-content.full-content {
     font-size: 1rem;
     font-weight: 600;
     color: rgba(244, 248, 247, 0.95);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 #customize-main.customize-layout:not(.hub-layout) #left-sidebar .variant-summary-card__action {

--- a/templates/generate/main-content.php
+++ b/templates/generate/main-content.php
@@ -21,7 +21,6 @@
                 <div class="variant-panel">
                         <header class="variant-panel__header">
                                 <div class="variant-panel__heading">
-                                        <p class="variant-panel__eyebrow">Sélection</p>
                                         <h2 class="variant-panel__title">Choisissez votre modèle</h2>
                                         <p class="variant-panel__description">
                                                 Explorez les produits disponibles et sélectionnez la variante idéale pour vos visuels générés.

--- a/templates/generate/sidebar-header.php
+++ b/templates/generate/sidebar-header.php
@@ -38,7 +38,7 @@
     <!-- Conteneur pour le bouton de génération -->
     <div id="aspect-ratio-container" class="aspect-ratio-container">
         <div id="buttons-container">
-            <button type="submit" id="validate-button">Générer</button>
+            <button type="submit" id="validate-button">✨ Générer mon visuel</button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the redundant "Sélection" and "Variantes disponibles" headings from the variant chooser
- cap the displayed width of variant cards and allow long product names to wrap in the summary card
- refresh the sidebar call-to-action button text to "✨ Générer mon visuel"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10cd03e508322a037c55e542aac37