### PR TITLE
Scope WooCommerce input styles to plugin forms

### DIFF
--- a/styles/account.css
+++ b/styles/account.css
@@ -631,8 +631,8 @@ td:last-child {
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
-.woocommerce-js input,
-.woocommerce-js textarea {
+.woocommerce-js .woocommerce input,
+.woocommerce-js .woocommerce textarea {
   background: rgba(28, 28, 28, 0.92) !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   border-radius: 12px !important;


### PR DESCRIPTION
## Summary
- limit the WooCommerce input styling rules to elements within WooCommerce containers so they do not affect global inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13123864c83229d5b4ce53ddbec44