### PR TITLE
Disable default WooCommerce stylesheets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,6 +20,9 @@ add_filter(
                 return $classes;
         }
 );
+
+// Désactive complètement les feuilles de style par défaut de WooCommerce
+add_filter( 'woocommerce_enqueue_styles', '__return_empty_array' );
 add_filter('woocommerce_order_actions', function($actions) {
     $actions['test_action'] = '🚀 Test bouton';
     return $actions;

--- a/styles/account.css
+++ b/styles/account.css
@@ -631,8 +631,8 @@ td:last-child {
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
-.woocommerce-js input,
-.woocommerce-js textarea {
+.woocommerce-js .woocommerce input,
+.woocommerce-js .woocommerce textarea {
   background: rgba(28, 28, 28, 0.92) !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   border-radius: 12px !important;


### PR DESCRIPTION
## Summary
- disable WooCommerce's bundled styles so the plugin no longer overrides the site's input styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13123864c83229d5b4ce53ddbec44