### PR TITLE
Increase spacing between login modal inputs

### DIFF
--- a/styles/modal-login.css
+++ b/styles/modal-login.css
@@ -174,6 +174,10 @@
     align-items: center;
 }
 
+.login-box .input-group + .input-group {
+    margin-top: 14px;
+}
+
 .input-icon {
     position: absolute;
     left: 16px;


### PR DESCRIPTION
## Summary
- add margin between consecutive input groups in the authentication modal to space the fields more comfortably

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e146627d7c8322ae5b6bf437c4946d