### PR TITLE
Add back navigation control to signup modal

### DIFF
--- a/js/account/sign_modal.js
+++ b/js/account/sign_modal.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', function() {
 	const showSignup = document.getElementById('showSignup');
 	const showEmailSignup = document.getElementById('showEmailSignup');
 	const showLogin = document.getElementById('showLogin');
-	const closeModalButtons = document.querySelectorAll('.close');
+        const closeModalButtons = document.querySelectorAll('.close');
+        const backButtons = document.querySelectorAll('.back-button');
 	const socialButtons = document.querySelectorAll('.social-button');
 
         socialButtons.forEach(button => {
@@ -34,9 +35,19 @@ document.addEventListener('DOMContentLoaded', function() {
 		switchView(emailSignupBox);
 	});
 
-	showLogin.addEventListener('click', function() {
-		switchView(loginBox);
-	});
+        showLogin.addEventListener('click', function() {
+                switchView(loginBox);
+        });
+
+        backButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                        const targetId = button.getAttribute('data-target');
+                        const targetElement = document.getElementById(targetId);
+                        if (targetElement) {
+                                switchView(targetElement);
+                        }
+                });
+        });
 
 	closeModalButtons.forEach(button => {
 		button.addEventListener('click', function() {

--- a/styles/modal-login.css
+++ b/styles/modal-login.css
@@ -106,6 +106,32 @@
     transform: translate(24px, -24px) scale(1.05);
 }
 
+.back-button {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translate(-24px, -24px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.08);
+    color: #6df2d2;
+    font-size: 18px;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+    background: rgba(109, 242, 210, 0.18);
+    color: #ffffff;
+    transform: translate(-24px, -24px) scale(1.05);
+}
+
 .social-button {
     width: 100%;
     display: inline-flex;

--- a/templates/modal-login.php
+++ b/templates/modal-login.php
@@ -48,6 +48,9 @@ $signup_nonce = wp_create_nonce('signup_nonce');
 			<!-- Étape intermédiaire avant inscription -->
                         <div class="login-box" id="signupOptions" style="display: none;">
                                 <button type="button" class="close" aria-label="Fermer le module d'inscription">✖</button>
+                                <button type="button" class="back-button" data-target="signin" aria-label="Retour à la connexion">
+                                        <span aria-hidden="true">←</span>
+                                </button>
                                <div class="login-heading">
                                        <h2 class="title">Créer votre compte Customiizer</h2>
                                </div>
@@ -64,6 +67,9 @@ $signup_nonce = wp_create_nonce('signup_nonce');
                         <!-- Inscription avec adresse e-mail -->
                         <div class="login-box" id="signup" style="display: none;">
                                 <button type="button" class="close" aria-label="Fermer le module d'inscription">✖</button>
+                                <button type="button" class="back-button" data-target="signupOptions" aria-label="Retour à l'étape précédente">
+                                        <span aria-hidden="true">←</span>
+                                </button>
                                <div class="login-heading">
                                        <h2 class="title">Inscription avec votre e-mail</h2>
                                </div>


### PR DESCRIPTION
## Summary
- add a back navigation arrow to the signup steps in the authentication modal
- style the arrow control to match existing modal chrome
- hook up the button to return users to the requested previous step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1469e7a808322ab3b38bc92863076