### PR TITLE
Move login modal close button to right panel

### DIFF
--- a/styles/modal-login.css
+++ b/styles/modal-login.css
@@ -82,14 +82,13 @@
 
 .close {
     position: absolute;
-    top: 0;
-    right: 0;
-    transform: translate(24px, -24px);
+    top: clamp(16px, 3vw, 28px);
+    right: clamp(16px, 3vw, 28px);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
     border: none;
     background: rgba(255, 255, 255, 0.08);
@@ -97,13 +96,14 @@
     font-size: 18px;
     cursor: pointer;
     transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+    z-index: 2;
 }
 
 .close:hover,
 .close:focus-visible {
     background: rgba(109, 242, 210, 0.18);
     color: #ffffff;
-    transform: translate(24px, -24px) scale(1.05);
+    transform: scale(1.05);
 }
 
 .social-button {

--- a/templates/modal-login.php
+++ b/templates/modal-login.php
@@ -9,10 +9,10 @@ $signup_nonce = wp_create_nonce('signup_nonce');
 
 <div id="loginModal" class="login-modal" style="display: none;">
         <div class="loginModal-content">
+                <button type="button" class="close" aria-label="Fermer le module d'authentification">✖</button>
                 <div class="form-container">
                         <!-- Partie Connexion -->
                         <div class="login-box" id="signin">
-                                <button type="button" class="close" aria-label="Fermer le module de connexion">✖</button>
                                <div class="login-heading">
                                        <h2 class="title">Bienvenue sur Customiizer&nbsp;!</h2>
                                        <p class="new-user-prompt">Pas encore de compte&nbsp;? <a href="#" id="showSignup">Créer un compte</a></p>
@@ -45,9 +45,8 @@ $signup_nonce = wp_create_nonce('signup_nonce');
                                 <input type="hidden" id="signin-nonce" value="<?php echo esc_attr( $signin_nonce ); ?>">
                         </div>
 
-			<!-- Étape intermédiaire avant inscription -->
+                        <!-- Étape intermédiaire avant inscription -->
                         <div class="login-box" id="signupOptions" style="display: none;">
-                                <button type="button" class="close" aria-label="Fermer le module d'inscription">✖</button>
                                <div class="login-heading">
                                        <h2 class="title">Créer votre compte Customiizer</h2>
                                </div>
@@ -63,7 +62,6 @@ $signup_nonce = wp_create_nonce('signup_nonce');
 
                         <!-- Inscription avec adresse e-mail -->
                         <div class="login-box" id="signup" style="display: none;">
-                                <button type="button" class="close" aria-label="Fermer le module d'inscription">✖</button>
                                <div class="login-heading">
                                        <h2 class="title">Inscription avec votre e-mail</h2>
                                </div>
@@ -93,7 +91,6 @@ $signup_nonce = wp_create_nonce('signup_nonce');
                         </div>
                         <!-- Mot de passe oublié -->
                         <div class="login-box" id="forgotPassword" style="display: none;">
-                                <button type="button" class="close" aria-label="Fermer le module de récupération du mot de passe">✖</button>
                                <div class="login-heading">
                                        <h2 class="title">Mot de passe oublié&nbsp;?</h2>
                                </div>
@@ -108,7 +105,6 @@ $signup_nonce = wp_create_nonce('signup_nonce');
                         </div>
                         <!-- Réinitialisation du mot de passe -->
                         <div class="login-box" id="resetPasswordSection" style="display: none;">
-                                <button type="button" class="close" aria-label="Fermer le module de nouveau mot de passe">✖</button>
                                <div class="login-heading">
                                        <h2 class="title">Définir un nouveau mot de passe</h2>
                                </div>


### PR DESCRIPTION
## Summary
- add a single close control for the login modal content so it sits in the right-hand section
- update modal styles to position the close button in the upper-right corner of the dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e146cdd35c8322a9921623f5eb5d4b